### PR TITLE
Add openpyxl to dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(
     install_requires=[
         'pyomo',
         'pandas==1.2.*',
+        'openpyxl',
     ],
     maintainer="Keith Beattie",
     maintainer_email="ksbeattie@lbl.gov",


### PR DESCRIPTION
@drouvenm @MAZamarripa @Andresj89 is there any function or module that uses all of our dependencies? It would just be a "smoke test" for the moment, so it doesn't have to particularly make sense, but having something more than just the lone import statement that we have now would be an improvement in terms of automated testing.