### PR TITLE
Fixing no print argument issue with generate_report method

### DIFF
--- a/pareto/utilities/results.py
+++ b/pareto/utilities/results.py
@@ -26,66 +26,68 @@ def generate_report(model, is_print=[]):
     printing_list = []
 
     if model.type == "strategic":
-
-        # PrintValues.Detailed: Slacks values included, Same as "All"
-        if is_print[0].value == 0:
-            printing_list = [
-                "v_F_Piped",
-                "v_F_Trucked",
-                "v_F_Sourced",
-                "v_F_PadStorageIn",
-                "v_F_ReuseDestination",
-                "v_X_Capacity",
-                "v_T_Capacity",
-                "v_F_Capacity",
-                "v_D_Capacity",
-                "v_F_DisposalDestination",
-                "v_F_PadStorageOut",
-                "v_C_Piped",
-                "v_C_Trucked",
-                "v_C_Sourced",
-                "v_C_Disposal",
-                "v_C_Reuse",
-                "v_L_Storage",
-                "vb_y_Pipeline",
-                "vb_y_Disposal",
-                "vb_y_Storage",
-                "vb_y_Treatment",
-                "vb_y_FLow",
-                "v_F_Overview",
-                "v_S_FracDemand",
-                "v_S_Production",
-                "v_S_Flowback",
-                "v_S_PipelineCapacity",
-                "v_S_StorageCapacity",
-                "v_S_DisposalCapacity",
-                "v_S_TreatmentCapacity",
-                "v_S_ReuseCapacity",
-            ]
-
-        # PrintValues.Nominal: Essential + Trucked water + Piped Water + Sourced water + vb_y_pipeline + vb_y_disposal + vb_y_storage + etc.
-        elif is_print[0].value == 1:
-            printing_list = [
-                "v_F_Piped",
-                "v_F_Trucked",
-                "v_F_Sourced",
-                "v_C_Piped",
-                "v_C_Trucked",
-                "v_C_Sourced",
-                "vb_y_Pipeline",
-                "vb_y_Disposal",
-                "vb_y_Storage",
-                "vb_y_Flow",
-                "vb_y_Treatment",
-                "v_F_Overview",
-            ]
-
-        # PrintValues.Essential: Just message about slacks, "Check detailed results", Overview, Economics, KPIs
-        elif is_print[0].value == 2:
-            printing_list = ["v_F_Overview"]
-
+        if len(is_print) == 0:
+            printing_list = []
         else:
-            raise Exception("Report {0} not supported".format(is_print))
+            # PrintValues.Detailed: Slacks values included, Same as "All"
+            if is_print[0].value == 0:
+                printing_list = [
+                    "v_F_Piped",
+                    "v_F_Trucked",
+                    "v_F_Sourced",
+                    "v_F_PadStorageIn",
+                    "v_F_ReuseDestination",
+                    "v_X_Capacity",
+                    "v_T_Capacity",
+                    "v_F_Capacity",
+                    "v_D_Capacity",
+                    "v_F_DisposalDestination",
+                    "v_F_PadStorageOut",
+                    "v_C_Piped",
+                    "v_C_Trucked",
+                    "v_C_Sourced",
+                    "v_C_Disposal",
+                    "v_C_Reuse",
+                    "v_L_Storage",
+                    "vb_y_Pipeline",
+                    "vb_y_Disposal",
+                    "vb_y_Storage",
+                    "vb_y_Treatment",
+                    "vb_y_FLow",
+                    "v_F_Overview",
+                    "v_S_FracDemand",
+                    "v_S_Production",
+                    "v_S_Flowback",
+                    "v_S_PipelineCapacity",
+                    "v_S_StorageCapacity",
+                    "v_S_DisposalCapacity",
+                    "v_S_TreatmentCapacity",
+                    "v_S_ReuseCapacity",
+                ]
+
+            # PrintValues.Nominal: Essential + Trucked water + Piped Water + Sourced water + vb_y_pipeline + vb_y_disposal + vb_y_storage + etc.
+            elif is_print[0].value == 1:
+                printing_list = [
+                    "v_F_Piped",
+                    "v_F_Trucked",
+                    "v_F_Sourced",
+                    "v_C_Piped",
+                    "v_C_Trucked",
+                    "v_C_Sourced",
+                    "vb_y_Pipeline",
+                    "vb_y_Disposal",
+                    "vb_y_Storage",
+                    "vb_y_Flow",
+                    "vb_y_Treatment",
+                    "v_F_Overview",
+                ]
+
+            # PrintValues.Essential: Just message about slacks, "Check detailed results", Overview, Economics, KPIs
+            elif is_print[0].value == 2:
+                printing_list = ["v_F_Overview"]
+
+            else:
+                raise Exception("Report {0} not supported".format(is_print))
 
         headers = {
             "v_F_Overview_dict": [("Variable Name", "Documentation", "Total")],
@@ -174,69 +176,72 @@ def generate_report(model, is_print=[]):
         model.reuse_CompletionsDemandKPI.value = reuseDemand_value
 
     elif model.type == "operational":
-        # PrintValues.Detailed: Slacks values included, Same as "All"
-        if is_print[0].value == 0:
-            printing_list = [
-                "v_F_Piped",
-                "v_F_Trucked",
-                "v_F_Sourced",
-                "v_F_PadStorageIn",
-                "v_L_ProdTank",
-                "v_F_PadStorageOut",
-                "v_C_Piped",
-                "v_C_Trucked",
-                "v_C_Sourced",
-                "v_C_Disposal",
-                "v_C_Reuse",
-                "v_L_Storage",
-                "vb_y_Pipeline",
-                "vb_y_Disposal",
-                "vb_y_Storage",
-                "vb_y_Truck",
-                "v_F_Drain",
-                "v_B_Production",
-                "vb_y_FLow",
-                "v_F_Overview",
-                "v_L_PadStorage",
-                "v_C_Treatment",
-                "v_C_Storage",
-                "v_R_Storage",
-                "v_S_FracDemand",
-                "v_S_Production",
-                "v_S_Flowback",
-                "v_S_PipelineCapacity",
-                "v_S_StorageCapacity",
-                "v_S_DisposalCapacity",
-                "v_S_TreatmentCapacity",
-                "v_S_ReuseCapacity",
-                "v_D_Capacity",
-                "v_X_Capacity",
-                "v_F_Capacity",
-            ]
-
-        # PrintValues.Nominal: Essential + Trucked water + Piped Water + Sourced water + vb_y_pipeline + vb_y_disposal + vb_y_storage
-        elif is_print[0].value == 1:
-            printing_list = [
-                "v_F_Piped",
-                "v_F_Trucked",
-                "v_F_Sourced",
-                "v_C_Piped",
-                "v_C_Trucked",
-                "v_C_Sourced",
-                "vb_y_Pipeline",
-                "vb_y_Disposal",
-                "vb_y_Storage",
-                "vb_y_Flow",
-                "vb_y_Truck",
-                "v_F_Overview",
-            ]
-
-        # PrintValues.Essential: Just message about slacks, "Check detailed results", Overview, Economics, KPIs
-        elif is_print[0].value == 2:
-            printing_list = ["v_F_Overview"]
-
+        if len(is_print) == 0:
+            printing_list = []
         else:
-            raise Exception("Report {0} not supported".format(is_print))
+            # PrintValues.Detailed: Slacks values included, Same as "All"
+            if is_print[0].value == 0:
+                printing_list = [
+                    "v_F_Piped",
+                    "v_F_Trucked",
+                    "v_F_Sourced",
+                    "v_F_PadStorageIn",
+                    "v_L_ProdTank",
+                    "v_F_PadStorageOut",
+                    "v_C_Piped",
+                    "v_C_Trucked",
+                    "v_C_Sourced",
+                    "v_C_Disposal",
+                    "v_C_Reuse",
+                    "v_L_Storage",
+                    "vb_y_Pipeline",
+                    "vb_y_Disposal",
+                    "vb_y_Storage",
+                    "vb_y_Truck",
+                    "v_F_Drain",
+                    "v_B_Production",
+                    "vb_y_FLow",
+                    "v_F_Overview",
+                    "v_L_PadStorage",
+                    "v_C_Treatment",
+                    "v_C_Storage",
+                    "v_R_Storage",
+                    "v_S_FracDemand",
+                    "v_S_Production",
+                    "v_S_Flowback",
+                    "v_S_PipelineCapacity",
+                    "v_S_StorageCapacity",
+                    "v_S_DisposalCapacity",
+                    "v_S_TreatmentCapacity",
+                    "v_S_ReuseCapacity",
+                    "v_D_Capacity",
+                    "v_X_Capacity",
+                    "v_F_Capacity",
+                ]
+
+            # PrintValues.Nominal: Essential + Trucked water + Piped Water + Sourced water + vb_y_pipeline + vb_y_disposal + vb_y_storage
+            elif is_print[0].value == 1:
+                printing_list = [
+                    "v_F_Piped",
+                    "v_F_Trucked",
+                    "v_F_Sourced",
+                    "v_C_Piped",
+                    "v_C_Trucked",
+                    "v_C_Sourced",
+                    "vb_y_Pipeline",
+                    "vb_y_Disposal",
+                    "vb_y_Storage",
+                    "vb_y_Flow",
+                    "vb_y_Truck",
+                    "v_F_Overview",
+                ]
+
+            # PrintValues.Essential: Just message about slacks, "Check detailed results", Overview, Economics, KPIs
+            elif is_print[0].value == 2:
+                printing_list = ["v_F_Overview"]
+
+            else:
+                raise Exception("Report {0} not supported".format(is_print))
 
         headers = {
             "v_F_Overview_dict": [("Variable Name", "Documentation", "Total")],


### PR DESCRIPTION
## Summary
generate_report was throwing an error if `is_print` did not have any input value. This PR sovles that issue, `is_print` argument can now receive no value and the method will simply not print any information

### Suggested reviewers
@Andresj89 @MAZamarripa @drouvenm 