### PR TITLE
Extend solver utilities for #75

### DIFF
--- a/pareto/tests/test_solvers.py
+++ b/pareto/tests/test_solvers.py
@@ -108,12 +108,12 @@ class TestMultipleSolverChoices:
     _VALID_NAME = "ipopt"
 
     @pytest.mark.parametrize(
-        'names,expectation',
+        "names,expectation",
         [
-            (('bogus1', _VALID_NAME, "bogus2"), does_not_raise()),
-            (('bogus1', "bogus2"), pytest.raises(SolverError)),
+            (("bogus1", _VALID_NAME, "bogus2"), does_not_raise()),
+            (("bogus1", "bogus2"), pytest.raises(SolverError)),
         ],
-        ids=get_readable_param
+        ids=get_readable_param,
     )
     def test_valid_choice_is_instantiated(self, names, expectation):
         with expectation:

--- a/pareto/utilities/solvers.py
+++ b/pareto/utilities/solvers.py
@@ -17,7 +17,7 @@ from typing import Iterable
 
 class SolverError(ValueError):
     "Base exception for solver-related errors"
-    
+
 
 class NoAvailableSolver(SolverError):
     def __init__(self, *choices: Iterable[str]):
@@ -86,6 +86,8 @@ def set_timeout(solver: OptSolver, timeout_s: Number) -> OptSolver:
     }
     option_key = name_key_mapping.get(solver.name, None)
     if option_key is None:
-        raise SolverError(f"No timeout option mapping found for {solver}: {name_key_mapping}")
+        raise SolverError(
+            f"No timeout option mapping found for {solver}: {name_key_mapping}"
+        )
     solver.options[option_key] = float(timeout_s)
     return solver

--- a/pareto/utilities/testing.py
+++ b/pareto/utilities/testing.py
@@ -19,11 +19,11 @@ import _pytest
 def get_readable_param(obj: Any):
     """
     Return a more readable representation of an object.
-    
+
     Use as the `ids` argument of parametrize/pytest.mark.parametrize.
     """
     if isinstance(obj, (tuple, list)):
-        return str.join(',', obj)
+        return str.join(",", obj)
     if "RaisesContext" in type(obj).__name__:
         return "(should raise)"
     if isinstance(obj, does_not_raise):


### PR DESCRIPTION
This PR adds extra functionality to `pareto.utilities.solvers` (on top of #73 and #76) so that it's possible to concisely instantiate and configure a solver from a list of names in order of decreasing priority:

```py
from pareto.utilities.solvers import get_solver, set_timeout
solver = get_solver("gurobi_direct", "gurobi", "cbc")
set_timeout(solver, 60)
```