### PR TITLE
Add pre-commit checks for formatting and staged files (stagedfright)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,7 @@ dmypy.json
 
 # Ignore temporary Excel files
 ~$*.xlsx
+
+# stagedfright 
+
+*.stagedfright-allowed

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,5 +9,7 @@ repos:
       - id: black-check
         name: Black (check)
         language: system
-        entry: black --check pareto
+        entry: black --check .
+        types: 
+          - python
         verbose: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,11 @@
 repos:
   - repo: local
     hooks:
+      - id: stagedfright
+        name: stagedfright
+        language: system
+        entry: stagedfright .stagedfright
+        verbose: true
       - id: black-check
         name: Black (check)
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: local
+    hooks:
+      - id: black-check
+        name: Black (check)
+        language: system
+        entry: black --check pareto
+        verbose: true

--- a/.stagedfright/README.md
+++ b/.stagedfright/README.md
@@ -119,8 +119,8 @@ Assuming that the file to be commited is `pareto/data/sample-data.csv`:
 - The allowfile `pareto/data/sample-data.csv.stagedfright-allowed` exists, but is empty
   - **NO GO**: the allowfile must contain a string that matches the staged file's current fingerprint,
     defined as the SHA256 hash of the file's binary content
-  - The current fingerprint can be obtained by running the `sha256 <path>` command on Unix or `CertUtil -hashfile <path> SHA256` on Windows
-- The allowfile `pareto/data/sample-data.csv.stagedfright-allowed` exists and contains a SHA256 has,
+  - The current fingerprint can be obtained by running the `sha256sum <path>` command on Unix or `CertUtil -hashfile <path> SHA256` on Windows
+- The allowfile `pareto/data/sample-data.csv.stagedfright-allowed` exists and contains a SHA256 hash,
   but the staged file has been modified since the hash was computed, i.e. the allowfile contains an outdated fingerprint
   for the staged file
   - **NO GO**: the fingerprint in the allowfile must match the staged file's *current* content

--- a/.stagedfright/README.md
+++ b/.stagedfright/README.md
@@ -1,0 +1,145 @@
+# stagedfright: Pre-commit detection of sensitive files
+
+## Introduction
+
+The main goal of this tool is to prevent sensitive files (SF) from being **unintentionally** committed to a Git repository.
+
+### How it works
+
+- Staged files are files that have been added to the Git index (a.k.a. *staging area*) by commands such as `git add` (aliased to `git stage` for recent versions of Git).
+- When the script is installed as a pre-commit hook (see below), it will be run automatically by Git when a commit is initiated by the user, e.g. invoking the `git commit` command.
+- The commit will be blocked (i.e. the `git commit` will terminate with an error, and no file will be committed) unless all of the staged files are *cleared for commit* by the script.
+
+### Inspecting staged files
+
+- By design, any staged file is considered *unguarded* by default and is only cleared for commit after passing all of the specified checks
+- A staged file is cleared for commit if **either** of these condition is true:
+  - The file passes all the checks defined in the `checks.py` file in this directory
+  - A special *allowfile* is found in the repository. The allowfile must have the following properties:
+    - It must be located in the same directory as the staged file
+    - Its name must match the staged file's name, plus the special *allowfile suffix* `.stagedfright-allowed`
+    - It must be a text file containing the staged file's fingerprint, defined as the SHA256 hash of the staged file's byte contents
+
+For a more detailed breakdown of this script's limitations and capabilities, continue to the "Functionality" section.
+
+## Getting started
+
+**IMPORTANT** As this is still experimental, it is recommended to use a separate local clone of the repository to be used for testing, e.g. by doing a fresh `git clone` in a dedicated directory.
+
+### Installing as a pre-commit hook
+
+stagedfright is installed automatically as part of the `project-pareto` Python installation.
+
+To use stagedfright as a pre-commit hook, PARETO developers can run this command in their developer environment after installing the developer dependencies defined in `requirements-dev.txt`:
+
+```sh
+pre-commit install
+```
+
+### Testing the script
+
+1. Activate your development Conda environment
+2. Navigate to the local clone of the repository to be used for testing
+3. Create or modify files as needed to reproduce the desired scenario involving SFs ending up in the repo's working tree
+4. Stage those changes using `git add`/`git stage`
+5. Try to commit using `git commit`. The script should run, resulting in its output being displayed and (if needed) the commit being cancelled
+6. To remove the staged files, use `git reset`/`git restore` (refer to [this How-To guide](https://git-scm.com/book/en/v2/Git-Basics-Undoing-Things) for more information)
+
+## Functionality
+
+If we think of stagedfright as a *filter* operating on staged files with the goal of detecting SFs, we can classify possible scenarios according to the following schema, based on whether an SF was set to be added to the repo (positive) or not (negative), and whether the commit operation was allowed to continue (GO) or not (NO GO).
+
+- **True positive**: an SF was set to be added to the repo, and the operation was NO GO
+- **False positive**: no SF was set to be added to the repo, but the operation was NO GO
+- **True negative**: no SF was set to be added to the repo, and the operation was GO
+- **False negative**: an SF was set to be added to the repo, but the operation was GO
+
+In this perspective, the performance of this tool can be evaluated based on how well it satisfies the following requirements, in order of descending importance:
+
+- Minimize **false negatives**
+- Minimize **false positives**
+
+### True positives
+
+> Desired outcome: NO GO, actual outcome: NO GO
+
+By design (i.e. if this is not true, it's a bug), the checks should be able to detect
+ the following SFs after they end up in the repo and are staged:
+
+- A binary file with a non-`py` extension 
+  - **NO GO**: fails `has_py_path_suffix`
+- A binary file accidentally saved with a `py` extension
+  - **NO GO**: passes `has_py_path_suffix` but fails `is_text_file`
+- A text file in a non-Python format (e.g. CSV, JSON) accidentally saved under a filename with `py` extension
+  - **NO GO**: passes `has_py_path_suffix` and `is_text_file`, but fails `has_meaningful_python_code`
+- A Python source file containing hard-coded data definitions of numerical data
+  - **NO GO**: fails `py_module_does_not_contain_hardcoded_data` **if** the maximum number of allowed data definitions
+    is required to be sufficiently low
+
+### True negatives
+
+> Desired outcome: GO, actual outcome: GO
+
+By design, the checks should pass for the following staged files that are intended to be staged and committed:
+
+- A binary file, after the corresponding allowfile has been created
+  - **GO**, **if** the allowfile's content matches the current fingerprint (SHA256 has) of the staged file
+- A normal python source file
+  - **GO**, **if** the hardcoded data defined in it are below the maximum value required by the `py_module_does_not_contain_hardcoded_data` check
+
+### False positives
+
+> Desired outcome: GO, actual outcome: NO GO
+
+These scenarios occur when a file was supposed to be cleared for commit (i.e. is not an SF),
+but was erroneously flagged as unguarded.
+
+In general, stagedfright operates under a "presumption of guilt" principle:
+each staged file is considered unguarded (potentially sensitive) until proven otherwise.
+In this sense, any staged file that is not actually sensitive but is not a Python source file with the characteristics described above
+will result in a NO GO commit outcome by default.
+This can be considered a "baseline" false positive resulting from 
+the fundamental strictness/convenience tradeoff under which stagedfright operates.
+
+To get around this and allow developers to stage and commit a desired file without bypassing the checks entirely,
+stagedfright uses *allowfiles*, a sentinel file named after the staged file that informs stagedfright that the file has been staged intentionally.
+
+To reduce the possibility of false negatives, allowfiles must match certain criteria to be detected correctly.
+If an allowfile was created but does not match any of these criteria, the commit outcome will be NO GO even though
+the developer intended the file to be committed.
+
+In this sense, the following cases would be false positives in a stricter sense,
+although this is still completely within stagedfright's intended behavior.
+Assuming that the file to be commited is `pareto/data/sample-data.csv`:
+
+- The allowfile `pareto/data/sample-data.stagedfright-allowed` exists
+  - **NO GO**: the allowfile's name must contain the full name of the staged file, including its original extension
+- The allowfile `pareto/sample-data.csv.stagedfright-allowed` exists
+  - **NO GO**: the allowfile must be placed in the same subdirectory as the staged file
+- The allowfile `pareto/data/sample-data.csv.stagedfright-allowed` exists, but is empty
+  - **NO GO**: the allowfile must contain a string that matches the staged file's current fingerprint,
+    defined as the SHA256 hash of the file's binary content
+  - The current fingerprint can be obtained by running the `sha256 <path>` command on Unix or `CertUtil -hashfile <path> SHA256` on Windows
+- The allowfile `pareto/data/sample-data.csv.stagedfright-allowed` exists and contains a SHA256 has,
+  but the staged file has been modified since the hash was computed, i.e. the allowfile contains an outdated fingerprint
+  for the staged file
+  - **NO GO**: the fingerprint in the allowfile must match the staged file's *current* content
+  - To address this, compute again the staged file's fingerprint and modify or recreate the allowfile with the new value
+
+**NOTE**: As a convenience, at the end of the inspection procedure, stagedfright will display the list of unguarded staged files together with the name of the allowfile and the fingerprint, which can be used to (manually, by design) create the allowfile
+  
+### False negatives
+
+> Desired outcome: NO GO, actual outcome: GO
+
+By design (i.e., again, assuming stagedfright operates as intended), sensitive data can still make its way in the repository in two general scenarios:
+
+- Sensitive data is inserted in a Python source file that passes all of stagedfright's checks: the definition of "sensitive data" is very broad and can potentially include e.g. a single number or string, which would pass the current check for hardcoded numeric constants defined in a Python module
+  - To mitigate this, the checks and their parameters should be carefully designed and optimized based on the expected features of sensitive data being handled, while keeping in mind that stricter selection criteria typically results in an increase of false positives over true negatives
+- Wrong allowfile being created: for example, if the repo contains both `a.txt` (which should be committed) and `b.txt` (which should not be committed), the allowfile `b.txt.stagedfright-allowed` exists and it contains the correct fingerprint for `b.txt`, then if `b.txt` is staged and the commit operation will not be blocked
+
+## Limitations
+
+Last but not least, it is important to remark that stagedfright can only be effective if it is correctly configured in the repo, and, more importantly that there are still countless scenarios that stagedfright is unable to prevent.
+
+The best way to think about stagedfright is as one among many many layers of protection in the "swiss cheese" model of incident prevention, for which following the protocol is critical for optimal performance.

--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -13,17 +13,22 @@ from stagedfright import StagedFile, AllowFile, PyContent
 
 
 def test_allowfile_matches_if_present(staged: StagedFile, allowfile: AllowFile):
-    assert staged.fingerprint == allowfile.fingerprint, f"An allowfile must contain a matching fingerprint for a staged file to be cleared for commit"
+    assert (
+        staged.fingerprint == allowfile.fingerprint
+    ), f"An allowfile must contain a matching fingerprint for a staged file to be cleared for commit"
 
 
-@pytest.mark.usefixtures('skip_if_matching_allowfile')
+@pytest.mark.usefixtures("skip_if_matching_allowfile")
 class TestIsClearedForCommit:
-
     def test_has_py_path_suffix(self, staged: StagedFile):
-        assert staged.suffix in {".py"}, "Only files with a 'py' extension may be cleared for commit"
+        assert staged.suffix in {
+            ".py"
+        }, "Only files with a 'py' extension may be cleared for commit"
 
     def test_is_text_file(self, staged: StagedFile):
-        assert staged.text_content is not None, "Only source (text) files may be cleared for commit"
+        assert (
+            staged.text_content is not None
+        ), "Only source (text) files may be cleared for commit"
 
     def test_has_meaningful_python_code(self, staged_pycontent: PyContent):
         assert len(staged_pycontent.ast_nodes.essential) >= 2
@@ -31,9 +36,12 @@ class TestIsClearedForCommit:
     @pytest.fixture
     def hardcoded_data_definitions(self, staged_pycontent: PyContent) -> List[ast.AST]:
         return [
-            n for n in staged_pycontent.ast_nodes.literal
+            n
+            for n in staged_pycontent.ast_nodes.literal
             if isinstance(n.value, numbers.Number) and n.value != 0
         ]
 
-    def test_py_module_does_not_contain_hardcoded_data(self, hardcoded_data_definitions: List[ast.AST]):
+    def test_py_module_does_not_contain_hardcoded_data(
+        self, hardcoded_data_definitions: List[ast.AST]
+    ):
         assert len(hardcoded_data_definitions) <= 2

--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -1,0 +1,39 @@
+"""
+These checks are used by stagedfright to determine whether a staged file is cleared for commit or not.
+The check suite should be optimized and optimized based on the features of the specific sensitive data formats and features being handled.
+For more information, see the README.md file in this directory.
+"""
+
+import ast
+import numbers
+from typing import List
+
+import pytest
+from stagedfright import StagedFile, AllowFile, PyContent
+
+
+def test_allowfile_matches_if_present(staged: StagedFile, allowfile: AllowFile):
+    assert staged.fingerprint == allowfile.fingerprint, f"An allowfile must contain a matching fingerprint for a staged file to be cleared for commit"
+
+
+@pytest.mark.usefixtures('skip_if_matching_allowfile')
+class TestIsClearedForCommit:
+
+    def test_has_py_path_suffix(self, staged: StagedFile):
+        assert staged.suffix in {".py"}, "Only files with a 'py' extension may be cleared for commit"
+
+    def test_is_text_file(self, staged: StagedFile):
+        assert staged.text_content is not None, "Only source (text) files may be cleared for commit"
+
+    def test_has_meaningful_python_code(self, staged_pycontent: PyContent):
+        assert len(staged_pycontent.ast_nodes.essential) >= 2
+
+    @pytest.fixture
+    def hardcoded_data_definitions(self, staged_pycontent: PyContent) -> List[ast.AST]:
+        return [
+            n for n in staged_pycontent.ast_nodes.literal
+            if isinstance(n.value, numbers.Number) and n.value != 0
+        ]
+
+    def test_py_module_does_not_contain_hardcoded_data(self, hardcoded_data_definitions: List[ast.AST]):
+        assert len(hardcoded_data_definitions) <= 2

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ which means that any modification made to the code in the cloned directory
 (including switching to a different branch with `git switch`/`git checkout`, or updating the directory with `git pull`) will be available when using the package in Python,
 regardless of e.g. the current working directory.
 
+Install the pre-commit checks that will run automatically whenever `git commit` is used, preventing the commit from being created if any of the checks fail:
+
+```sh
+pre-commit install
+```
+
 Install the open-source solvers packaged by the IDAES project:
 
 ```sh
@@ -115,3 +121,5 @@ To reproduce this check locally (e.g. to verify that your code would pass this c
 ```sh
 black --check .
 ```
+
+**NOTE**: This is now done automatically as part of the pre-commit checks (see above).

--- a/README.md
+++ b/README.md
@@ -65,11 +65,6 @@ Install the Python package using pip and the `requirements-dev.txt` file:
 pip install -r requirements-dev.txt
 ```
 
-The developer installation will install the cloned directory in editable mode (as opposed to the default behavior of installing a copy of it),
-which means that any modification made to the code in the cloned directory
-(including switching to a different branch with `git switch`/`git checkout`, or updating the directory with `git pull`) will be available when using the package in Python,
-regardless of e.g. the current working directory.
-
 Install the pre-commit checks that will run automatically whenever `git commit` is used, preventing the commit from being created if any of the checks fail:
 
 ```sh
@@ -89,6 +84,13 @@ pytest --verbose
 ```
 
 ## Notes for developers
+
+### Editable installation with pip
+
+The developer installation will install the Python packages and modules found in the cloned directory in editable mode (as opposed to the default behavior of installing a copy of it),
+which means that any modification made to the code in the cloned directory
+(including switching to a different branch with `git switch`/`git checkout`, or updating the directory with `git pull`) will be available when using the package in Python,
+regardless of e.g. the current working directory.
 
 ### Formatting code with Black
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest==6.2.*
 black==21.7b0
+pre-commit==2.16.*
 addheader
 --editable .

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
         ]
     },
     entry_points={
-        'console_scripts': [
-            'stagedfright=stagedfright:main',
+        "console_scripts": [
+            "stagedfright=stagedfright:main",
         ]
     },
     maintainer="Keith Beattie",

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ setup(
     name=NAME,
     version=VERSION,
     packages=find_packages(),
+    py_modules=["stagedfright"],
     install_requires=[
         "pyomo<6.1",
         "pandas==1.2.*",
@@ -23,6 +24,11 @@ setup(
         # If any package contains these files, include them:
         "": [
             "*.xlsx",
+        ]
+    },
+    entry_points={
+        'console_scripts': [
+            'stagedfright=stagedfright:main',
         ]
     },
     maintainer="Keith Beattie",

--- a/stagedfright.py
+++ b/stagedfright.py
@@ -1,0 +1,336 @@
+import ast
+import collections
+from dataclasses import dataclass
+import hashlib
+import logging
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Callable, Optional, Union, Iterable, Iterator, List, Tuple
+
+import pytest
+from _pytest.terminal import TerminalReporter
+
+
+NAME = "stagedfright"
+__version__ = "2021.12.20"
+__author__ = "Ludovico Bianchi <lbianchi@lbl.gov>"
+
+
+_logger = logging.getLogger(NAME)
+
+
+ALLOWFILE_SUFFIX = ".stagedfright-allowed"
+
+
+class RepoOperationError(RuntimeError):
+    @classmethod
+    def from_subprocess_run(cls, completed_process):
+        return cls(
+            f"Repository operation with args {completed_process.args} did not succeed.\n"
+            f"returncode={completed_process.returncode}\n"
+            f"stderr={completed_process.stderr}"
+        )
+
+
+def _get_git_output(args: Iterable[str], git_exe: os.PathLike = "git") -> str:
+    args = [git_exe] + list(args)
+    _logger.debug(f"subprocess args: {args}")
+    res = subprocess.run(
+        args,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if res.returncode != 0:
+        raise RepoOperationError.from_subprocess_run(res)
+    return res.stdout
+
+
+def get_repo_root_dir() -> Path:
+    try:
+        path = _get_git_output(["rev-parse", "--show-toplevel"]).strip()
+    except RepoOperationError as e:
+        _logger.exception("Could not obtain repository root from git.")
+        raise e
+    return Path(path).resolve()
+
+
+def get_git_staged_paths() -> List[Path]:
+    try:
+        lines = _get_git_output(["diff", "--staged", "--name-only"]).splitlines()
+    except RepoOperationError as e:
+        _logger.exception("Could not get staged files from git.")
+        raise e
+
+    return [Path(p) for p in lines]
+
+
+_BasePathType = type(Path())
+
+
+class StagedFile(_BasePathType):
+    @property
+    def fingerprint(self) -> str:
+        h = hashlib.sha256()
+        h.update(self.read_bytes())
+        return h.hexdigest()
+
+    @property
+    def text_content(self) -> Union[str, None]:
+        try:
+            return self.read_text()
+        except UnicodeDecodeError:
+            return None
+
+    @classmethod
+    def from_paths(cls, paths: Iterable[Path]) -> Iterator["StagedFile"]:
+        for path in paths:
+            if not path.is_file():
+                _logger.warning(
+                    f'Trying to instantiate {cls} from "{path}", but it is not an existing file'
+                )
+            else:
+                yield cls(path)
+
+    @classmethod
+    def from_git_staged(cls) -> Iterator["StagedFile"]:
+        yield from cls.from_paths(get_git_staged_paths())
+
+
+class AllowFile(_BasePathType):
+    @classmethod
+    def from_path(cls, path: Path) -> "AllowFile":
+        return cls(path.with_name(path.name + ALLOWFILE_SUFFIX))
+
+    @property
+    def fingerprint(self) -> str:
+        return self.read_text().strip()
+
+
+@dataclass
+class ASTNodes:
+    @classmethod
+    def from_source(cls, src: str, **kwargs):
+        return cls(root=ast.parse(src), **kwargs)
+
+    root: ast.AST
+    essential_types: Optional[Tuple[type]] = (ast.Assign, ast.Import, ast.ImportFrom)
+    literal_types: Optional[Tuple[type]] = ast.Constant
+
+    essential: Optional[List[ast.AST]] = None
+    literal: Optional[List[ast.AST]] = None
+
+    def __iter__(self):
+        yield from ast.walk(self.root)
+
+    def __post_init__(self):
+        self.essential = [n for n in self if isinstance(n, self.essential_types)]
+        self.literal = [n for n in self if isinstance(n, self.literal_types)]
+
+    @property
+    def literal_values(self) -> List:
+        return [n.value for n in self.literal]
+
+
+@dataclass
+class PyContent:
+    source: str
+    ast_nodes: Optional[ASTNodes] = None
+    objects: Optional[dict] = None
+
+    def __post_init__(self):
+        if self.ast_nodes is None:
+            self.ast_nodes = ASTNodes.from_source(self.source)
+
+
+class StagedFright:
+    def __init__(self, items=None):
+        self.test_reports = collections.defaultdict(list)
+        self._items = list(items or [])
+        self.current = None
+
+    @pytest.hookimpl(tryfirst=True, hookwrapper=True)
+    def pytest_runtest_makereport(self, item, call) -> None:
+        outcome = yield
+        rep = outcome.get_result()
+        self.test_reports[self.current].append(rep)
+
+    def pytest_generate_tests(self, metafunc) -> None:
+        # if
+        if "staged" in metafunc.fixturenames:
+            metafunc.parametrize("staged", self._items, ids=str, indirect=True)
+
+    @pytest.fixture(scope="module")
+    # @pytest.fixture(scope="module", params=list(StagedFile.from_git_staged()), ids=os.fspath)
+    def staged(self, request) -> StagedFile:
+        staged = request.param
+        self.current = staged
+        yield staged
+
+    @pytest.fixture
+    def skip_if_matching_allowfile(self, staged: StagedFile) -> None:
+        allowfile = AllowFile.from_path(staged)
+        if not allowfile.exists():
+            return
+        if staged.fingerprint == allowfile.fingerprint:
+            pytest.skip(f'Matching allowfile found for "{staged}"')
+
+    @pytest.fixture
+    def allowfile(self, staged: StagedFile) -> AllowFile:
+        af = AllowFile.from_path(staged)
+        if not af.exists():
+            pytest.skip(f"No allowfile found for {staged}")
+        return af
+
+    @pytest.fixture
+    def staged_pycontent(self, staged: StagedFile) -> PyContent:
+        if staged.text_content is None:
+            pytest.xfail(f"{staged} is not a text file")
+        return PyContent(staged.text_content)
+
+    @property
+    def with_failing_tests(self) -> List:
+        return [
+            entry
+            for entry, reports in self.test_reports.items()
+            if not all([rep.outcome in {"passed", "skipped"} for rep in reports])
+        ]
+
+    def pytest_terminal_summary(self, terminalreporter: TerminalReporter) -> None:
+        to_report = self.with_failing_tests
+        tr = terminalreporter
+
+        tr.section(NAME)
+        tr.write_line(
+            f"The following {len(to_report)} staged file(s) had one or more failing tests:"
+        )
+        for staged in to_report:
+            tr.write_line(f"\t{staged}")
+
+        tr.write_line(
+            "For each of these files, REVIEW IT CAREFULLY:"
+            "\n- If it *SHOULD NOT* be cleared for commit, unstage it immediately."
+            "\n- If instead it should, create an allowfile in the same directory, "
+            f'with the same name (including file extension) plus the "{ALLOWFILE_SUFFIX}" suffix, '
+            "containing the fingerprint (SHA256 hash) of the file."
+        )
+
+        tr.ensure_newline()
+        tr.write_line("\te.g.:")
+        for staged in self.with_failing_tests:
+            allowfile = AllowFile.from_path(staged)
+            tr.write_line(
+                f'\tFor staged file "{staged}", create "{allowfile}" with content: {staged.fingerprint}'
+            )
+
+
+def pytest_run(
+    to_inspect: Iterable[Path],
+    testpath: os.PathLike,
+    verbose: bool = True,
+    ignore_ini_file: bool = True,
+    collect_all: bool = True,
+) -> pytest.ExitCode:
+
+    items = list(StagedFile.from_paths(to_inspect))
+
+    testpath = Path(testpath).resolve()
+
+    _logger.info(
+        f"Inspecting {len(items)} staged items using checks collected from {testpath}"
+    )
+
+    sf = StagedFright(items)
+
+    pytest_args = [
+        os.fspath(testpath),
+        "-s",
+    ]
+
+    if collect_all:
+        pytest_args += ["-o", "python_files=*.py"]
+
+    if ignore_ini_file:
+        null_target = "NUL" if sys.platform.startswith("win") else "/dev/null"
+        pytest_args += ["-c", null_target]
+
+    pytest_args += ["-v"] if verbose else ["-qq"]
+
+    _logger.debug(f"Calling pytest.main with args: {pytest_args}")
+
+    return pytest.main(
+        pytest_args,
+        plugins=[sf],
+    )
+
+
+class ExitCode:
+    no_unguarded_detected: int = 0
+    unguarded_detected: int = 1
+    internal_error: int = 2
+    no_inspection_performed: int = 5
+
+
+def notify_exit(code: int, log: Callable[[str], None] = _logger.info):
+    log(f"{NAME} will now exit with code: {code}")
+    return code
+
+
+def main(args: Optional[List[str]] = None) -> int:
+    logging.basicConfig(level=logging.DEBUG)
+
+    _logger.info(f"{NAME}, version: {__version__}")
+
+    args = args or sys.argv[1:]
+    _logger.debug(f"args={args}")
+
+    try:
+        root_dir = get_repo_root_dir()
+    except RepoOperationError:
+        _logger.critical("Could not determine the root of the repository. ")
+        return notify_exit(ExitCode.internal_error)
+    else:
+        _logger.info(f"Starting inspection for repository directory: {root_dir}")
+
+    try:
+        staged_paths = get_git_staged_paths()
+    except RepoOperationError:
+        _logger.critical(f"Could not determine staged files for this repository.")
+        return notify_exit(ExitCode.internal_error)
+    else:
+        _logger.info(f"{len(staged_paths)} items are currently staged")
+        if _logger.isEnabledFor(logging.DEBUG):
+            for path in staged_paths:
+                _logger.debug(f"\t{path}")
+
+    if not staged_paths:
+        _logger.warning(f"No staged files detected.")
+        return notify_exit(ExitCode.no_inspection_performed)
+
+    # TODO add properly parsed arguments
+    testfile = args[0]
+
+    try:
+        pytest_run_res = pytest_run(staged_paths, testfile, verbose=True)
+    except Exception as e:
+        _logger.exception("Unexpected error occurred during inspection.")
+        _logger.critical(
+            "Inspection could not be completed because of an internal error."
+        )
+        return notify_exit(ExitCode.internal_error)
+
+    _logger.debug(f"pytest run result: {pytest_run_res}")
+    _logger.info("Inspection completed successfully.")
+
+    if pytest_run_res == 0:
+        _logger.info("No unguarded files have been detected.")
+        return notify_exit(ExitCode.no_unguarded_detected)
+
+    _logger.error("Unguarded files have been detected.")
+    return notify_exit(ExitCode.unguarded_detected)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/stagedfright.py
+++ b/stagedfright.py
@@ -199,12 +199,16 @@ class StagedFright:
         ]
 
     def pytest_terminal_summary(self, terminalreporter: TerminalReporter) -> None:
-        to_report = self.with_failing_tests
         tr = terminalreporter
-
         tr.section(NAME)
+
+        to_report = self.with_failing_tests
+        if not to_report:
+            tr.write_line("No failed checks among the inspected staged files.")
+            return
+
         tr.write_line(
-            f"The following {len(to_report)} staged file(s) had one or more failing tests:"
+            f"The following {len(to_report)} inspected staged file(s) failed one or more checks:"
         )
         for staged in to_report:
             tr.write_line(f"\t{staged}")


### PR DESCRIPTION
This PR adds code, configuration, and documentation to enable automated pre-commit checks to run locally. These checks use the `pre-commit` framework and will block a commit (i.e. cause the `git commit` command to fail) until all checks pass. The currently enabled checks are:

- Black (check): prevent a commit if one or more Python files haven't been formatted, avoiding the need to push and wait for the GitHub Actions workflow to perform the check preventing
- stagedfright: inspect staged files as a safeguard against accidentally committing unintended files, addressing #7 