### PR TITLE
stagedfright: Make check for hardcoded data more specific by checking per-file count

### DIFF
--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -23,8 +23,16 @@ MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
     "pareto/tests/test_operational_model.py": 11,
     "pareto/utilities/get_data.py": 24,
     "pareto/utilities/results": 91,
-    ".stagedfright/checks.py": 7,
 }
+
+# this is meta, two levels deep:
+# - this file is also included checked by stagedfright,
+#   so the hardcoded data used to define this mapping must be counted,
+# - the extra number accounts for constants defined below,
+#   plus 1 for the fact that this number itself is defined using a constant
+MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT[".stagedfright/checks.py"] = (
+    len(MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT) + 3
+)
 
 
 @pytest.mark.usefixtures("skip_if_matching_allowfile")

--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -6,7 +6,8 @@ For more information, see the README.md file in this directory.
 
 import ast
 import numbers
-from typing import List
+from pathlib import Path
+from typing import List, Dict
 
 import pytest
 from stagedfright import StagedFile, AllowFile, PyContent
@@ -63,9 +64,19 @@ class TestIsClearedForCommit:
         return len(hardcoded_data_definitions)
 
     @pytest.fixture
-    def expected_hardcoded_data_count(self, staged: StagedFile) -> int:
-        key = str(staged)
-        return int(MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT.get(key, 0))
+    def _mapping_with_normalized_paths(self) -> Dict[str, int]:
+        # paths must be normalized (here, by using pathlib.Path objects instead of str)
+        # so that the same key in the mapping can be matched on both UNIX and Windows
+        return {Path(k): v for k, v in MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT.items()}
+
+    @pytest.fixture
+    def expected_hardcoded_data_count(
+        self,
+        staged: StagedFile,
+        _mapping_with_normalized_paths: Dict[str, int],
+    ) -> int:
+        key = Path(staged)
+        return int(_mapping_with_normalized_paths.get(key, 0))
 
     def test_py_module_has_no_unexpected_hardcoded_data(
         self,

--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -21,9 +21,10 @@ def test_allowfile_matches_if_present(staged: StagedFile, allowfile: AllowFile):
 
 MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
     "pareto/operational_water_management/run_operational_model.py": 5,
+    "pareto/operational_water_management/operational_produced_water_optimization_model.py": 71,
     "pareto/tests/test_operational_model.py": 11,
     "pareto/utilities/get_data.py": 24,
-    "pareto/utilities/results": 91,
+    "pareto/utilities/results.py": 91,
 }
 
 # this is meta, two levels deep:

--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -18,6 +18,15 @@ def test_allowfile_matches_if_present(staged: StagedFile, allowfile: AllowFile):
     ), f"An allowfile must contain a matching fingerprint for a staged file to be cleared for commit"
 
 
+MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
+    "pareto/operational_water_management/run_operational_model.py": 5,
+    "pareto/tests/test_operational_model.py": 11,
+    "pareto/utilities/get_data.py": 24,
+    "pareto/utilities/results": 91,
+    ".stagedfright/checks.py": 7,
+}
+
+
 @pytest.mark.usefixtures("skip_if_matching_allowfile")
 class TestIsClearedForCommit:
     def test_has_py_path_suffix(self, staged: StagedFile):
@@ -41,7 +50,19 @@ class TestIsClearedForCommit:
             if isinstance(n.value, numbers.Number) and n.value != 0
         ]
 
-    def test_py_module_does_not_contain_hardcoded_data(
-        self, hardcoded_data_definitions: List[ast.AST]
+    @pytest.fixture
+    def hardcoded_data_count(self, hardcoded_data_definitions: List[ast.AST]) -> int:
+        return len(hardcoded_data_definitions)
+
+    @pytest.fixture
+    def expected_hardcoded_data_count(self, staged: StagedFile) -> int:
+        key = str(staged)
+        return int(MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT.get(key, 0))
+
+    def test_py_module_has_no_unexpected_hardcoded_data(
+        self,
+        hardcoded_data_count: int,
+        expected_hardcoded_data_count: int,
+        max_added_count=2,
     ):
-        assert len(hardcoded_data_definitions) <= 2
+        assert hardcoded_data_count <= (expected_hardcoded_data_count + max_added_count)


### PR DESCRIPTION
Following @melody-shellman's feedback after testing stagedfright, she pointed out a limitation in the current version of stagedfright that causes frequent false positives when working with Python files:

- Currently, the check for hardcoded values only takes into account the number of definitions found in the *current* version of the file, without taking into account the hardcoded values that are already present in the file, and that the count is different from file to file
- A more specific test would look at the changes between a reference version of the file (e.g. the one on the `main` branch) and the staged version, and fail the check if the two version differ significantly
  - This functionality would be useful in stagedfright (not only for this specific check, but more in general), but it requires a bit of work to be implemented
- In the meantime, we figured that a usable alternative would be to make the check more specific by keeping a list of the expected number of hardcoded data definition for commonly used files, so that the check only fails if more than the expected number are found (with a configurable tolerance, currently set to 2)
  - This reduces the number of false positives (since the check will only require an allowfile if n > 2 hardcoded data definitions are detected)
  - A possible cause of false negatives is if in the staged version of the file an equal number of hardcoded data definition is removed and added, since at the moment only the total count is considered
    - Possible ways to address this are being considered

Feel free to test this version and see if it addresses the limitations of the current version. In the meantime, I'll keep thinking of more ways to make this check, and other checks on Python files, more specific