### PR TITLE
Add configuration for ReadTheDocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,7 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  fail_on_warning: true
+  fail_on_warning: false
 
 build:
   os: ubuntu-20.04

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,24 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  fail_on_warning: true
+
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.9"
+
+python:
+  install:
+    - requirements: requirements-dev.txt
+
+# Build all formats
+formats:
+  - pdf
+  - htmlzip


### PR DESCRIPTION
## Motivation

- PARETO needs special configuration to be able to build the documentation using ReadTheDocs, which has to be provided in a `.readthedocs.yaml` file in the repository
- For more information, see https://docs.readthedocs.io/en/stable/config-file/v2.html#conda-environment

## Changes proposed in this PR:

- Add `.readthedocs.yaml` configuration file for RTD

---

## TODO before merging

- [ ] Fix warnings and re-enable strict warnings in config file

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
