### PR TITLE
Fixing Warning in get_data

### DIFF
--- a/pareto/utilities/get_data.py
+++ b/pareto/utilities/get_data.py
@@ -79,7 +79,7 @@ def _read_data(_fname, _set_list, _parameter_list):
     for i in _df_parameters:
         if proprietary_data is False:
             proprietary_data = any(
-                x in _df_parameters[i].values for x in keyword_strings
+                x in _df_parameters[i].values.astype(str) for x in keyword_strings
             )
             if proprietary_data is False:
                 proprietary_data = any(


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

When performing the comparison between keywords and values in a `_df_parameters` the error reported in issue #87 occurred

## Changes proposed in this PR:
-  I modified line 82 in `get_data()` as follows:
 `_df_parameters[i].values` -> `_df_parameters[i].values.astype(str)` so that both sides of the comparison had the same `type`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
