### PR TITLE
Add discrete water quality to the model

### DIFF
--- a/pareto/strategic_water_management/run_strategic_model.py
+++ b/pareto/strategic_water_management/run_strategic_model.py
@@ -12,6 +12,7 @@
 #####################################################################################################
 
 from pareto.strategic_water_management.strategic_produced_water_optimization import (
+    WaterQuality,
     create_model,
     Objectives,
     solve_model,
@@ -111,7 +112,10 @@ with resources.path(
  objective: [Objectives.cost, Objectives.reuse]
  pipeline_cost: [PipelineCost.distance_based, PipelineCost.capacity_based]
  pipeline_capacity: [PipelineCapacity.input, PipelineCapacity.calculated]
- node_capacity: [IncludeNodeCapacity.True, IncludeNodeCapacity.False]"""
+ node_capacity: [IncludeNodeCapacity.true, IncludeNodeCapacity.false]
+ water_quality: [WaterQuality.false, WaterQuality.post_process, WaterQuality.discrete]
+ """
+
 strategic_model = create_model(
     df_sets,
     df_parameters,
@@ -120,6 +124,7 @@ strategic_model = create_model(
         "pipeline_cost": PipelineCost.distance_based,
         "pipeline_capacity": PipelineCapacity.input,
         "node_capacity": IncludeNodeCapacity.true,
+        "water_quality": WaterQuality.discrete,
     },
 )
 
@@ -129,7 +134,6 @@ options = {
     "scaling_factor": 1000000,
     "running_time": 60,
     "gap": 0,
-    "water_quality": True,
 }
 solve_model(model=strategic_model, options=options)
 

--- a/pareto/tests/test_solvers.py
+++ b/pareto/tests/test_solvers.py
@@ -47,7 +47,7 @@ def nlp():
     m.x = pyo.Var(initialize=-0.1)
     m.y = pyo.Var(initialize=1)
     m.c = pyo.Constraint(expr=m.x >= 1)
-    m.obj = pyo.Objective(expr=m.x**2 + m.y**2)
+    m.obj = pyo.Objective(expr=m.x ** 2 + m.y ** 2)
     return m, 1
 
 
@@ -58,7 +58,7 @@ def minlp():
     m.i = pyo.Var(domain=pyo.Binary, initialize=1)
     m.c = pyo.Constraint(expr=m.x >= 1)
     m.obj = pyo.Objective(
-        expr=m.i * (m.x**2 + m.y**2) + (1 - m.i) * 4 * (m.x**2 + m.y**2)
+        expr=m.i * (m.x ** 2 + m.y ** 2) + (1 - m.i) * 4 * (m.x ** 2 + m.y ** 2)
     )
     return m, 1
 

--- a/pareto/utilities/results.py
+++ b/pareto/utilities/results.py
@@ -175,6 +175,146 @@ def generate_report(model, is_print=[], fname=None):
             "v_F_CompletionsDestination_dict": [
                 ("Pads", "Time", "Total deliveries to completions pads")
             ],
+            "v_Q_CompletionPad_dict": [
+                ("Completion pad", "Water Component", "Time", "Water Quality")
+            ],
+            "v_Q_Discrete_dict": [
+                (
+                    "Location",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    " Water Quality",
+                )
+            ],
+            "v_F_DiscretePiped_dict": [
+                (
+                    "Origin",
+                    "Destination",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Piped water",
+                )
+            ],
+            "v_F_DiscreteTrucked_dict": [
+                (
+                    "Origin",
+                    "Destination",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Trucked water",
+                )
+            ],
+            "v_F_DiscreteDisposalDestination_dict": [
+                (
+                    "Disposal Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Total Deliveries to Disposal Site",
+                )
+            ],
+            "v_F_DiscreteFlowOutStorage_dict": [
+                (
+                    "Storage Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Total outflow storage site",
+                )
+            ],
+            "v_L_DiscreteStorage_dict": [
+                (
+                    "Storage Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Storage Levels",
+                )
+            ],
+            "v_F_DiscreteFlowTreatment_dict": [
+                (
+                    "Treatment Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Treated water",
+                )
+            ],
+            "v_F_DiscreteFlowOutNode_dict": [
+                (
+                    "Node",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Total outflow node",
+                )
+            ],
+            "v_F_DiscreteBeneficialReuseDestination_dict": [
+                (
+                    "Reuse Location",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Beneficial water",
+                )
+            ],
+            "v_F_DiscreteFlowCompletionsPadIntermediate_dict": [
+                (
+                    "Completion pad intermediate",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Intermediate water",
+                )
+            ],
+            "v_F_DiscreteFlowCompletionsPadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Storage level out",
+                )
+            ],
+            "v_L_DiscretePadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Storage levels in",
+                )
+            ],
+            "v_F_DiscreteFlowOutPadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Outflow storage",
+                )
+            ],
+            "v_F_DiscreteFlowInPadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Inflow storage",
+                )
+            ],
+            "v_F_DiscreteCompletionsDestination_dict": [
+                (
+                    "Completion pad intermediate",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Intermediate water completion pad",
+                )
+            ],
         }
 
         # Defining KPIs for strategic model
@@ -351,6 +491,146 @@ def generate_report(model, is_print=[], fname=None):
             "v_F_UnusedTreatedWater_dict": [
                 ("Treatment site", "Time", "Treatment Waste Water")
             ],
+            "v_Q_CompletionPad_dict": [
+                ("Completion pad", "Water Component", "Time", "Water Quality")
+            ],
+            "v_Q_Discrete_dict": [
+                (
+                    "Location",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    " Water Quality",
+                )
+            ],
+            "v_F_DiscretePiped_dict": [
+                (
+                    "Origin",
+                    "Destination",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Piped water",
+                )
+            ],
+            "v_F_DiscreteTrucked_dict": [
+                (
+                    "Origin",
+                    "Destination",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Trucked water",
+                )
+            ],
+            "v_F_DiscreteDisposalDestination_dict": [
+                (
+                    "Disposal Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Total Deliveries to Disposal Site",
+                )
+            ],
+            "v_F_DiscreteFlowOutStorage_dict": [
+                (
+                    "Storage Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Total outflow storage site",
+                )
+            ],
+            "v_L_DiscreteStorage_dict": [
+                (
+                    "Storage Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Storage Levels",
+                )
+            ],
+            "v_F_DiscreteFlowTreatment_dict": [
+                (
+                    "Treatment Site",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Treated water",
+                )
+            ],
+            "v_F_DiscreteFlowOutNode_dict": [
+                (
+                    "Node",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Total outflow node",
+                )
+            ],
+            "v_F_DiscreteBeneficialReuseDestination_dict": [
+                (
+                    "Reuse Location",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Beneficial water",
+                )
+            ],
+            "v_F_DiscreteFlowCompletionsPadIntermediate_dict": [
+                (
+                    "Completion pad intermediate",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Intermediate water",
+                )
+            ],
+            "v_F_DiscreteFlowCompletionsPadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Storage level out",
+                )
+            ],
+            "v_L_DiscretePadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Storage levels in",
+                )
+            ],
+            "v_F_DiscreteFlowOutPadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Outflow storage",
+                )
+            ],
+            "v_F_DiscreteFlowInPadStorage_dict": [
+                (
+                    "Completion pad storage",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Inflow storage",
+                )
+            ],
+            "v_F_DiscreteCompletionsDestination_dict": [
+                (
+                    "Completion pad intermediate",
+                    "Time",
+                    "Water Component",
+                    "Discrete Water Quality",
+                    "Intermediate water completion pad",
+                )
+            ],
         }
         # Detect if the model has equalized or individual production tanks
         if model.config.production_tanks == ProdTank.equalized:
@@ -408,6 +688,9 @@ def generate_report(model, is_print=[], fname=None):
                 # in that case, "i" is redefined by adding a comma so that it becomes a tuple
                 elif i is not None and isinstance(i, str):
                     i = (i,)
+                # replace the discrete qualities by their actual values
+                if str(variable.name) == "v_Q_Discrete" and var_value > 0:
+                    var_value = model.p_discrete_quality[i[2], i[3]]
                 if i is not None and var_value is not None and var_value > 0:
                     headers[str(variable.name) + "_dict"].append((*i, var_value))
 
@@ -691,7 +974,7 @@ def handle_time(variable, input_data):
             raise Exception("User must provide labels when using Get_data format.")
 
 
-def outlet_flow(source=[], destination=[], label=[], value=[]):
+def outlet_flow(source=[], destination=[], label=[], value=[], qualityDict=[]):
     """
     The outlet_flow method receives source, destination, label, and value lists and
     sums the total value for each label. This value is then added to the label string and
@@ -719,6 +1002,10 @@ def outlet_flow(source=[], destination=[], label=[], value=[]):
             integer_output = str(int(integer_output / 1000)) + "k"
         elif value_length >= 8:
             integer_output = str(int(integer_output / 1000000)) + "M"
+        label_string = "{0}:{1}".format(l, integer_output)
+        if qualityDict:
+            quality_output = str(int(qualityDict[l] / 1000)) + "k"
+            label_string = "{0}:{1} TDS:{2}".format(l, integer_output, quality_output)
 
         label[x] = "{0}:{1}".format(l, integer_output)
 


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

When adding water quality to the model it will become a non-linear problem. One way to make it linear again is to discretize the water quality. The implementation of the discretization is Based on the paper "Investment Optimization Model for Freshwater Acquisition and Wastewater Handling in Shale Gas Production" (Linlin et al., 2015)

## Changes proposed in this PR:
- Add discrete water quality to the model
- Add constraints to handle discrete water quality
- Add scaling for the discrete water quality variables and constraints
- Add additional option to select if you want to run the model without water quality, with post process water quality or discrete water quality
- Update the results to include the discrete water quality variables
- Get initial solution by first fixing the qualities and afterwards the flows.

## Testing and Results:
- When create the model, set in the default dictionary the value for "water_quality" to WaterQuality.discrete

In the results excel you can find the quality for the completion pads in the tab "v_Q_CompletionPad, for the other nodes you can find it in v_Q_Discrete.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.


