### PR TITLE
Remove Unicode characters from Sphinx source files

### DIFF
--- a/docs/model_library/operational_water_management/index.rst
+++ b/docs/model_library/operational_water_management/index.rst
@@ -29,99 +29,99 @@ Operational Model Mathematical Notation
 
 **Sets**
 
-:math:`\textcolor{blue}{t ∈ T}`			                               Time periods (i.e. days)
+:math:`\textcolor{blue}{t \in T}`			                               Time periods (i.e. days)
 
-:math:`\textcolor{blue}{p ∈ P}`			                               Well pads
+:math:`\textcolor{blue}{p \in P}`			                               Well pads
 
-:math:`\textcolor{blue}{p ∈ PP}`			                           Production pads (subset of well pads P)
+:math:`\textcolor{blue}{p \in PP}`			                           Production pads (subset of well pads P)
 
-:math:`\textcolor{blue}{p ∈ CP}`  	                                   Completions pads (subset of well pads P)
+:math:`\textcolor{blue}{p \in CP}`  	                                   Completions pads (subset of well pads P)
 
-:math:`\textcolor{blue}{f ∈ F}`			                               Freshwater sources
+:math:`\textcolor{blue}{f \in F}`			                               Freshwater sources
 
-:math:`\textcolor{blue}{k ∈ K}`			                               Disposal sites
+:math:`\textcolor{blue}{k \in K}`			                               Disposal sites
 
-:math:`\textcolor{blue}{s ∈ S}`			                               Storage sites
+:math:`\textcolor{blue}{s \in S}`			                               Storage sites
 
-:math:`\textcolor{blue}{r ∈ R}`			                               Treatment sites
+:math:`\textcolor{blue}{r \in R}`			                               Treatment sites
 
-:math:`\textcolor{blue}{o ∈ O}`			                               Beneficial Reuse options
+:math:`\textcolor{blue}{o \in O}`			                               Beneficial Reuse options
 
-:math:`\textcolor{blue}{n ∈ N}`			                               Network nodes
+:math:`\textcolor{blue}{n \in N}`			                               Network nodes
 
-:math:`\textcolor{blue}{l ∈ L}`			                               Locations (superset of well pads, disposal sites, nodes, …)
+:math:`\textcolor{blue}{l \in L}`			                               Locations (superset of well pads, disposal sites, nodes, …)
 
-:math:`\textcolor{blue}{a ∈ A}`			                               Production tanks
-
-
-:math:`\textcolor{blue}{(p,p) ∈ PCA}`	                               Production-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(p,n) ∈ PNA}`                                 Production-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(p,p) ∈ PPA}`                                 Production-to-production pipeline arcs
-
-:math:`\textcolor{blue}{(p,n) ∈ CNA}`	                               Completions-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(p,p) ∈ CCA}`	                               Completions-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(n,n) ∈ NNA}`                                 Node-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(n,p) ∈ NCA}`                                 Node-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(n,k) ∈ NKA}`	                               Node-to-disposal pipeline arcs
-
-:math:`\textcolor{blue}{(n,s) ∈ NSA}`	                               Node-to-storage pipeline arcs
-
-:math:`\textcolor{blue}{(n,r) ∈ NRA}`                                 Node-to-treatment pipeline arcs
-
-:math:`\textcolor{blue}{(n,o) ∈ NOA}`	                               Node-to-beneficial reuse pipeline arcs
-
-:math:`\textcolor{blue}{(f,p) ∈ FCA}`	                               Freshwater-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(r,n) ∈ RNA}`	                               Treatment-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(r,p) ∈ RCA}`	                               Treatment-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(r,k) ∈ RKA}`	                               Treatment-to-disposal pipeline arcs
-
-:math:`\textcolor{blue}{(s,n) ∈ SNA}`	                               Storage-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(s,p) ∈ SCA}`	                               Storage-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(s,k) ∈ SKA}`	                               Storage-to-disposal pipeline arcs
-
-:math:`\textcolor{blue}{(s,r) ∈ SRA}`	                               Storage-to-treatment pipeline arcs
-
-:math:`\textcolor{blue}{(s,o) ∈ SOA}`	                               Storage-to-beneficial reuse pipeline arcs
+:math:`\textcolor{blue}{a \in A}`			                               Production tanks
 
 
-:math:`\textcolor{blue}{(p,p) ∈ PCT}`	                               Production-to-completions trucking arcs
+:math:`\textcolor{blue}{(p,p) \in PCA}`	                               Production-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(f,c) ∈ FCT}`                                 Freshwater-to-completions trucking arcs
+:math:`\textcolor{blue}{(p,n) \in PNA}`                                 Production-to-node pipeline arcs
 
-:math:`\textcolor{blue}{(p,k) ∈ PKT}`	                               Production-to-disposal trucking arcs
+:math:`\textcolor{blue}{(p,p) \in PPA}`                                 Production-to-production pipeline arcs
 
-:math:`\textcolor{blue}{(p,s) ∈ PST}`                                 Production-to-storage trucking arcs
+:math:`\textcolor{blue}{(p,n) \in CNA}`	                               Completions-to-node pipeline arcs
 
-:math:`\textcolor{blue}{(p,r) ∈ PRT}`	                               Production-to-treatment trucking arcs
+:math:`\textcolor{blue}{(p,p) \in CCA}`	                               Completions-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(p,o) ∈ POT}`	                               Production-to-beneficial reuse trucking arcs
+:math:`\textcolor{blue}{(n,n) \in NNA}`                                 Node-to-node pipeline arcs
 
-:math:`\textcolor{blue}{(p,k) ∈ CKT}`	                               Completions-to-disposal trucking arcs
+:math:`\textcolor{blue}{(n,p) \in NCA}`                                 Node-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(p,s) ∈ CST}`	                               Completions-to-storage trucking arcs
+:math:`\textcolor{blue}{(n,k) \in NKA}`	                               Node-to-disposal pipeline arcs
 
-:math:`\textcolor{blue}{(p,r) ∈ CRT}`                                 Completions-to-treatment trucking arcs
+:math:`\textcolor{blue}{(n,s) \in NSA}`	                               Node-to-storage pipeline arcs
 
-:math:`\textcolor{blue}{(p,p) ∈ CCT}`	                               Completions-to-completions trucking arcs (flowback reuse)
+:math:`\textcolor{blue}{(n,r) \in NRA}`                                 Node-to-treatment pipeline arcs
 
-:math:`\textcolor{blue}{(s,p) ∈ SCT}`                                 Storage-to-completions trucking arcs
+:math:`\textcolor{blue}{(n,o) \in NOA}`	                               Node-to-beneficial reuse pipeline arcs
 
-:math:`\textcolor{blue}{(s,k) ∈ SKT}`                                 Storage-to-disposal trucking arcs
+:math:`\textcolor{blue}{(f,p) \in FCA}`	                               Freshwater-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(r,k) ∈ RKT}`	                               Treatment-to-disposal trucking arcs
+:math:`\textcolor{blue}{(r,n) \in RNA}`	                               Treatment-to-node pipeline arcs
 
-:math:`\textcolor{blue}{(p,a) ∈ PAL}`	                               Pad-to-tank links
+:math:`\textcolor{blue}{(r,p) \in RCA}`	                               Treatment-to-completions pipeline arcs
+
+:math:`\textcolor{blue}{(r,k) \in RKA}`	                               Treatment-to-disposal pipeline arcs
+
+:math:`\textcolor{blue}{(s,n) \in SNA}`	                               Storage-to-node pipeline arcs
+
+:math:`\textcolor{blue}{(s,p) \in SCA}`	                               Storage-to-completions pipeline arcs
+
+:math:`\textcolor{blue}{(s,k) \in SKA}`	                               Storage-to-disposal pipeline arcs
+
+:math:`\textcolor{blue}{(s,r) \in SRA}`	                               Storage-to-treatment pipeline arcs
+
+:math:`\textcolor{blue}{(s,o) \in SOA}`	                               Storage-to-beneficial reuse pipeline arcs
+
+
+:math:`\textcolor{blue}{(p,p) \in PCT}`	                               Production-to-completions trucking arcs
+
+:math:`\textcolor{blue}{(f,c) \in FCT}`                                 Freshwater-to-completions trucking arcs
+
+:math:`\textcolor{blue}{(p,k) \in PKT}`	                               Production-to-disposal trucking arcs
+
+:math:`\textcolor{blue}{(p,s) \in PST}`                                 Production-to-storage trucking arcs
+
+:math:`\textcolor{blue}{(p,r) \in PRT}`	                               Production-to-treatment trucking arcs
+
+:math:`\textcolor{blue}{(p,o) \in POT}`	                               Production-to-beneficial reuse trucking arcs
+
+:math:`\textcolor{blue}{(p,k) \in CKT}`	                               Completions-to-disposal trucking arcs
+
+:math:`\textcolor{blue}{(p,s) \in CST}`	                               Completions-to-storage trucking arcs
+
+:math:`\textcolor{blue}{(p,r) \in CRT}`                                 Completions-to-treatment trucking arcs
+
+:math:`\textcolor{blue}{(p,p) \in CCT}`	                               Completions-to-completions trucking arcs (flowback reuse)
+
+:math:`\textcolor{blue}{(s,p) \in SCT}`                                 Storage-to-completions trucking arcs
+
+:math:`\textcolor{blue}{(s,k) \in SKT}`                                 Storage-to-disposal trucking arcs
+
+:math:`\textcolor{blue}{(r,k) \in RKT}`	                               Treatment-to-disposal trucking arcs
+
+:math:`\textcolor{blue}{(p,a) \in PAL}`	                               Pad-to-tank links
 
 
 
@@ -235,73 +235,73 @@ Operational Model Mathematical Notation
 
 **If the production tanks are separate, water level and water drainage are tracked at each individual production tank:**
 
-    :math:`\textcolor{green}{β_{p,a,t}^{Production}}` = 	           Produced water supply forecast for a production pad
+    :math:`\textcolor{green}{\beta_{p,a,t}^{Production}}` = 	           Produced water supply forecast for a production pad
 
-    :math:`\textcolor{green}{σ_{p,a}^{ProdTank}}` =	                   Production tank capacity
+    :math:`\textcolor{green}{\sigma_{p,a}^{ProdTank}}` =	                   Production tank capacity
 
-    :math:`\textcolor{green}{λ_{p,a}^{ProdTank}}` =	 	               Initial water level in production tank
+    :math:`\textcolor{green}{\lambda_{p,a}^{ProdTank}}` =	 	               Initial water level in production tank
 
 **Otherwise, if the production tanks are equalized, the water level and water drainage can be aggregated to a pad level:**
 
-    :math:`\textcolor{green}{β_{p,t}^{Production}}` =	               Produced water supply forecast for a production pad
+    :math:`\textcolor{green}{\beta_{p,t}^{Production}}` =	               Produced water supply forecast for a production pad
 
-    :math:`\textcolor{green}{σ_{p}^{ProdTank}}` =	                   Combined capacity of equalized production tanks
+    :math:`\textcolor{green}{\sigma_{p}^{ProdTank}}` =	                   Combined capacity of equalized production tanks
 
-    :math:`\textcolor{green}{λ_{p}^{ProdTank}}` =                      Initial water level in equalized production tanks
-
-
-:math:`\textcolor{green}{β_{p,t}^{Flowback}}` =	                       Flowback supply forecast for a completions pad
-
-:math:`\textcolor{green}{σ_{l,l}^{Pipeline}}` =	                       Daily pipeline capacity between two locations
-
-:math:`\textcolor{green}{σ_{k}^{Disposal}}` =	                       Daily disposal capacity at a disposal site
-
-:math:`\textcolor{green}{σ_{s}^{Storage}}` =                           Storage capacity at a storage site
-
-:math:`\textcolor{green}{σ_{p,t}^{PadStorage}}` =                      Storage capacity at completions site
-
-:math:`\textcolor{green}{σ_{r}^{Treatment}}` =                         Daily treatment capacity at a treatment site
-
-:math:`\textcolor{green}{σ_{o}^{BeneficialReuse}}` =                   Daily reuse capacity at a beneficial reuse site
-
-:math:`\textcolor{green}{σ_{f,t}^{Freshwater}}` =                      Daily freshwater sourcing capacity at freshwater source
-
-:math:`\textcolor{green}{σ_{p}^{Offloading,Pad}}` =                    Daily truck offloading sourcing capacity per pad
-
-:math:`\textcolor{green}{σ_{s}^{Offloading,Storage}}` =	               Daily truck offloading sourcing capacity per storage site
+    :math:`\textcolor{green}{\lambda_{p}^{ProdTank}}` =                      Initial water level in equalized production tanks
 
 
-:math:`\textcolor{green}{σ_{p}^{Processing,Pad}}` =                    Daily processing (e.g. clarification) capacity per pad
+:math:`\textcolor{green}{\beta_{p,t}^{Flowback}}` =	                       Flowback supply forecast for a completions pad
 
-:math:`\textcolor{green}{σ_{s}^{Processing,Storage}}` =                Daily processing (e.g. clarification) capacity at storage site
+:math:`\textcolor{green}{\sigma_{l,l}^{Pipeline}}` =	                       Daily pipeline capacity between two locations
 
-:math:`\textcolor{green}{ϵ_{r,w}^{Treatment}}` =                       Treatment efficiency for water quality component at treatment site
+:math:`\textcolor{green}{\sigma_{k}^{Disposal}}` =	                       Daily disposal capacity at a disposal site
 
-:math:`\textcolor{green}{δ^{Truck}}` =  Truck Capacity
+:math:`\textcolor{green}{\sigma_{s}^{Storage}}` =                           Storage capacity at a storage site
 
-:math:`\textcolor{green}{τ_{p,p}^{Trucking}}` =                        Drive time between two pads
+:math:`\textcolor{green}{\sigma_{p,t}^{PadStorage}}` =                      Storage capacity at completions site
 
-:math:`\textcolor{green}{τ_{p,k}^{Trucking}}` =	                       Drive time from a pad to a disposal site
+:math:`\textcolor{green}{\sigma_{r}^{Treatment}}` =                         Daily treatment capacity at a treatment site
 
-:math:`\textcolor{green}{τ_{p,s}^{Trucking}}` =	                       Drive time from a pad to a storage site
+:math:`\textcolor{green}{\sigma_{o}^{BeneficialReuse}}` =                   Daily reuse capacity at a beneficial reuse site
 
-:math:`\textcolor{green}{τ_{p,r}^{Trucking}}` =	                       Drive time from a pad to a treatment site
+:math:`\textcolor{green}{\sigma_{f,t}^{Freshwater}}` =                      Daily freshwater sourcing capacity at freshwater source
 
-:math:`\textcolor{green}{τ_{p,o}^{Trucking}}` =                        Drive time from a pad to a beneficial reuse site
+:math:`\textcolor{green}{\sigma_{p}^{Offloading,Pad}}` =                    Daily truck offloading sourcing capacity per pad
 
-:math:`\textcolor{green}{τ_{s,p}^{Trucking}}` =	                       Drive time from a storage site to a completions site
+:math:`\textcolor{green}{\sigma_{s}^{Offloading,Storage}}` =	               Daily truck offloading sourcing capacity per storage site
 
-:math:`\textcolor{green}{τ_{s,k}^{Trucking}}` =                        Drive time from a storage site to a disposal site
 
-:math:`\textcolor{green}{τ_{r,k}^{Trucking}}` =                        Drive time from a treatment site to a disposal site
+:math:`\textcolor{green}{\sigma_{p}^{Processing,Pad}}` =                    Daily processing (e.g. clarification) capacity per pad
 
-:math:`\textcolor{green}{λ_{s}^{Storage}}` =                           Initial storage level at storage site
+:math:`\textcolor{green}{\sigma_{s}^{Processing,Storage}}` =                Daily processing (e.g. clarification) capacity at storage site
 
-:math:`\textcolor{green}{λ_{p}^{PadStorage}}` =                        Initial storage level at completions site
+:math:`\textcolor{green}{\varepsilon_{r,w}^{Treatment}}` =                       Treatment efficiency for water quality component at treatment site
 
-:math:`\textcolor{green}{θ_{p}^{PadStorage}}` =                        Terminal storage level at completions site
+:math:`\textcolor{green}{\delta^{Truck}}` =  Truck Capacity
 
-:math:`\textcolor{green}{λ_{l,l}^{Pipeline}}` = 	                   Pipeline segment length
+:math:`\textcolor{green}{\tau_{p,p}^{Trucking}}` =                        Drive time between two pads
+
+:math:`\textcolor{green}{\tau_{p,k}^{Trucking}}` =	                       Drive time from a pad to a disposal site
+
+:math:`\textcolor{green}{\tau_{p,s}^{Trucking}}` =	                       Drive time from a pad to a storage site
+
+:math:`\textcolor{green}{\tau_{p,r}^{Trucking}}` =	                       Drive time from a pad to a treatment site
+
+:math:`\textcolor{green}{\tau_{p,o}^{Trucking}}` =                        Drive time from a pad to a beneficial reuse site
+
+:math:`\textcolor{green}{\tau_{s,p}^{Trucking}}` =	                       Drive time from a storage site to a completions site
+
+:math:`\textcolor{green}{\tau_{s,k}^{Trucking}}` =                        Drive time from a storage site to a disposal site
+
+:math:`\textcolor{green}{\tau_{r,k}^{Trucking}}` =                        Drive time from a treatment site to a disposal site
+
+:math:`\textcolor{green}{\lambda_{s}^{Storage}}` =                           Initial storage level at storage site
+
+:math:`\textcolor{green}{\lambda_{p}^{PadStorage}}` =                        Initial storage level at completions site
+
+:math:`\textcolor{green}{\theta_{p}^{PadStorage}}` =                        Terminal storage level at completions site
+
+:math:`\textcolor{green}{\lambda_{l,l}^{Pipeline}}` = 	                   Pipeline segment length
 
 :math:`\textcolor{green}{π_{k}^{Disposal}}` =                          Disposal operational cost
 
@@ -313,7 +313,7 @@ Operational Model Mathematical Notation
 
 :math:`\textcolor{green}{π_{p,t}^{PadStorage}}` =                      Completions pad operational cost
 
-:math:`\textcolor{green}{ρ_{s}^{Storage}}` =                           Storage withdrawal operational cgreenit
+:math:`\textcolor{green}{\rho_{s}^{Storage}}` =                           Storage withdrawal operational cgreenit
 
 :math:`\textcolor{green}{π_{l,l}^{Pipeline}}` =	                       Pipeline operational cost
 
@@ -324,21 +324,21 @@ Operational Model Mathematical Notation
 
 :math:`\textcolor{green}{M^{Flow}}` =                                  Big-M flow parameter
 
-:math:`\textcolor{green}{ψ^{FracDemand}}` =                            Slack cost parameter
+:math:`\textcolor{green}{\psi^{FracDemand}}` =                            Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{Production}}` =                            Slack cost parameter
+:math:`\textcolor{green}{\psi^{Production}}` =                            Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{Flowback}}` =                              Slack cost parameter
+:math:`\textcolor{green}{\psi^{Flowback}}` =                              Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{PipelineCapacity}}` =                      Slack cost parameter
+:math:`\textcolor{green}{\psi^{PipelineCapacity}}` =                      Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{StorageCapacity}}` =  	                   Slack cost parameter
+:math:`\textcolor{green}{\psi^{StorageCapacity}}` =  	                   Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{DisposalCapacity}}` =                      Slack cost parameter
+:math:`\textcolor{green}{\psi^{DisposalCapacity}}` =                      Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{TreamentCapacity}}` =                      Slack cost parameter
+:math:`\textcolor{green}{\psi^{TreamentCapacity}}` =                      Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{BeneficialReuseCapacity}}` =  	           Slack cost parameter
+:math:`\textcolor{green}{\psi^{BeneficialReuseCapacity}}` =  	           Slack cost parameter
 
 
 
@@ -359,68 +359,68 @@ The default objective function for this produced water operational model is to m
         \textcolor{red}{C^{TotalPiping}}+\textcolor{red}{C^{TotalStorage}}+\textcolor{red}{C^{TotalPadStorage}}+ \textcolor{red}{C^{TotalTrucking}}+\textcolor{red}{C^{Slack}-R^{TotalStorage}}
 
 
-**Completions Pad Demand Balance:** ∀p ∈ CP, t ∈ T
+**Completions Pad Demand Balance:** :math:`\forall p \in CP, t \in T`
 
 .. math::
 
-    \textcolor{green}{γ_{p,t}^{Completions}}=∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{green}{\gamma_{p,t}^{Completions}}=\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(f,p)∈FCA}\textcolor{red}{F_{l,l,t}^{Sourced}}
+        +\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(f,p)\in FCA}\textcolor{red}{F_{l,l,t}^{Sourced}}
 
-        +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(f,p)∈FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{F_{p,t}^{PadStorageOut}}-\textcolor{red}{F_{p,t}^{PadStorageIn}}+\textcolor{red}{S_{p,t}^{FracDemand}}
+        +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{F_{p,t}^{PadStorageOut}}-\textcolor{red}{F_{p,t}^{PadStorageIn}}+\textcolor{red}{S_{p,t}^{FracDemand}}
 
 
 
-**Completions Pad Storage Balance:** ∀p ∈ CP, t ∈ T
+**Completions Pad Storage Balance:** :math:`\forall p \in CP, t \in T`
 
 This constraint sets the storage level at the completions pad. For each completions pad and for each time period, completions pad storage is equal to storage in last time period plus water put in minus water removed. If it is the first time period, the pad storage is the initial pad storage.
 
 
 .. math::
 
-    \textcolor{red}{L_{p,t}^{PadStorage}} = \textcolor{green}{λ_{p,t=1}^{PadStorage}}+\textcolor{red}{L_{p,t-1}^{PadStorage}}+\textcolor{red}{F_{p,t}^{StorageIn}}-\textcolor{red}{F_{p,t}^{StorageOut}}
+    \textcolor{red}{L_{p,t}^{PadStorage}} = \textcolor{green}{\lambda_{p,t=1}^{PadStorage}}+\textcolor{red}{L_{p,t-1}^{PadStorage}}+\textcolor{red}{F_{p,t}^{StorageIn}}-\textcolor{red}{F_{p,t}^{StorageOut}}
 
 
 
-**Completions Pad Storage Capacity:** ∀p ∈ CP, t ∈ T
+**Completions Pad Storage Capacity:** :math:`\forall p \in CP, t \in T`
 
 The storage at each completions pad must always be at or below its capacity in every time period.
 
 .. math::
 
-    \textcolor{red}{L_{p,t}^{PadStorage}}≤\textcolor{red}{z_{p,t}^{PadStorage}}⋅\textcolor{green}{σ_{p,t}^{PadStorage}}
+    \textcolor{red}{L_{p,t}^{PadStorage}}≤\textcolor{red}{z_{p,t}^{PadStorage}} \cdot \textcolor{green}{\sigma_{p,t}^{PadStorage}}
 
-**Terminal Completions Pad Storage Level:** ∀p ∈ CP, t ∈ T
+**Terminal Completions Pad Storage Level:** :math:`\forall p \in CP, t \in T`
 
 .. math::
 
-    \textcolor{red}{L_{p,t=T}^{PadStorage}}≤\textcolor{green}{θ_{p}^{PadStorage}}
+    \textcolor{red}{L_{p,t=T}^{PadStorage}}≤\textcolor{green}{\theta_{p}^{PadStorage}}
 
 The storage in the last period must be at or below its terminal storage level.
 
 
 
-**Freshwater Sourcing Capacity:** ∀f ∈ F, t ∈ T
+**Freshwater Sourcing Capacity:** :math:`\forall f \in F, t \in T`
 
 For each freshwater source and each time period, the outgoing water from the freshwater source is below the freshwater capacity.
 
 .. math::
 
-      ∑_{(f,p)∈FCA}\textcolor{red}{F_{l,l,t}^{Sourced}} +∑_{(f,p)∈FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{f,t}^{Freshwater}}
+      \sum\nolimits_{-}{(f,p)\in FCA}\textcolor{red}{F_{l,l,t}^{Sourced}} +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{f,t}^{Freshwater}}
 
 
 
-**Completions Pad Truck Offloading Capacity:** ∀p ∈ CP, t ∈ T
+**Completions Pad Truck Offloading Capacity:** :math:`\forall p \in CP, t \in T`
 
 For each completions pad and time period, the volume of water being trucked into the completions pad must be below the trucking offloading capacity.
 
 .. math::
 
-    ∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(f,p)∈FCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{p}^{Offloading,Pad}}
+        +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{p}^{Offloading,Pad}}
 
 
 
@@ -430,34 +430,34 @@ For each completions pad and time period, the volume of water (excluding freshwa
 
 .. math::
 
-    ∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{p}^{Processing,Pad}}
+        +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{p}^{Processing,Pad}}
 
 
 .. note:: This constraint has not actually been implemented yet.
 
 
 
-**Storage Site Truck Offloading Capacity:** ∀p ∈ S, t ∈ T
+**Storage Site Truck Offloading Capacity:** :math:`\forall p \in S, t \in T`
 
 For each storage site and each time period, the volume of water being trucked into the storage site must be below the trucking offloading capacity for that storage site.
 
 .. math::
 
-    ∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{s}^{Offloading,Storage}}
+    \sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{s}^{Offloading,Storage}}
 
 
 
-**Storage Site Processing Capacity:** ∀s ∈ S, t ∈ T
+**Storage Site Processing Capacity:** :math:`\forall s \in S, t \in T`
 
 For each storage site and each time period, the volume of water being trucked into the storage site must be less than the processing capacity for that storage site.
 
 .. math::
 
-    ∑_{(n,s)∈NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{s}^{Processing,Storage}}
+    \sum\nolimits_{-}{(n,s)\in NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{s}^{Processing,Storage}}
 
 
 
@@ -465,18 +465,18 @@ For each storage site and each time period, the volume of water being trucked in
 
 If there are individual production tanks, the water level must be tracked at each tank. The water level at a given tank at the end of each period is equal to the water level at the previous period plus the flowback supply forecast at the pad minus the water that is drained.  If it is the first period, it is equal to the initial water level.
 
-For individual production tanks: ∀(p,a) ∈ PAL, t ∈ T
+For individual production tanks: \forall (p,a) \in PAL, t \in T
 
 .. math::
 
-    \textcolor{red}{L_{p,a,t}^{ProdTank}} = \textcolor{green}{λ_{p,a,t=1}^{ProdTank}}+\textcolor{red}{L_{p,a,t-1}^{ProdTank}}+\textcolor{green}{β_{p,a,t}^{Production}}-\textcolor{red}{F_{p,a,t}^{Drain}}
+    \textcolor{red}{L_{p,a,t}^{ProdTank}} = \textcolor{green}{\lambda_{p,a,t=1}^{ProdTank}}+\textcolor{red}{L_{p,a,t-1}^{ProdTank}}+\textcolor{green}{\beta_{p,a,t}^{Production}}-\textcolor{red}{F_{p,a,t}^{Drain}}
 
 
-For equalized production tanks: ∀p ∈ P, t ∈ T
+For equalized production tanks: \forall p \in P, t \in T
 
 .. math::
 
-    \textcolor{red}{L_{p,t}^{ProdTank}} = \textcolor{green}{λ_{p,t=1}^{ProdTank}}+\textcolor{red}{L_{p,t-1}^{ProdTank}}+\textcolor{green}{β_{p,t}^{Production}}-\textcolor{red}{F_{p,t}^{Drain}}
+    \textcolor{red}{L_{p,t}^{ProdTank}} = \textcolor{green}{\lambda_{p,t=1}^{ProdTank}}+\textcolor{red}{L_{p,t-1}^{ProdTank}}+\textcolor{green}{\beta_{p,t}^{Production}}-\textcolor{red}{F_{p,t}^{Drain}}
 
 
 
@@ -484,18 +484,18 @@ For equalized production tanks: ∀p ∈ P, t ∈ T
 
 The water level at the production tanks must always be below the production tank capacity.
 
-For individual production tanks: ∀(p,a) ∈ PAL, t ∈ T
+For individual production tanks: \forall (p,a) \in PAL, t \in T
 
 .. math::
 
-    \textcolor{red}{L_{p,a,t}^{ProdTank}}≤\textcolor{green}{σ_{p,a}^{ProdTank}}
+    \textcolor{red}{L_{p,a,t}^{ProdTank}}≤\textcolor{green}{\sigma_{p,a}^{ProdTank}}
 
 
-For equalized production tanks: ∀p ∈ P, t ∈ T
+For equalized production tanks: \forall p \in P, t \in T
 
 .. math::
 
-    \textcolor{red}{L_{p,t}^{ProdTank}}≤\textcolor{green}{σ_{p}^{ProdTank}}
+    \textcolor{red}{L_{p,t}^{ProdTank}}≤\textcolor{green}{\sigma_{p}^{ProdTank}}
 
 
 
@@ -503,18 +503,18 @@ For equalized production tanks: ∀p ∈ P, t ∈ T
 
 The water level at the production tanks in the final time period must be below the terminal production tank water level parameter.
 
-For individual production tanks: ∀(p,a) ∈ PAL, t ∈ T
+For individual production tanks: \forall (p,a) \in PAL, t \in T
 
 .. math::
 
-    \textcolor{red}{L_{p,a,t=T}^{ProdTank}}≤\textcolor{green}{λ_{p,a,t=1}^{ProdTank}}
+    \textcolor{red}{L_{p,a,t=T}^{ProdTank}}≤\textcolor{green}{\lambda_{p,a,t=1}^{ProdTank}}
 
 
-For equalized production tanks: ∀p ∈ P,t ∈ T
+For equalized production tanks: \forall p \in P,t \in T
 
 .. math::
 
-    \textcolor{red}{L_{p,t=T}^{ProdTank}}≤\textcolor{green}{λ_{p,t=1}^{ProdTank}}
+    \textcolor{red}{L_{p,t=T}^{ProdTank}}≤\textcolor{green}{\lambda_{p,t=1}^{ProdTank}}
 
 
 
@@ -522,16 +522,16 @@ For equalized production tanks: ∀p ∈ P,t ∈ T
 
 If there are individual production tanks, the water drained across all tanks at the completions pad must be equal to the produced water for transport at the pad.
 
-For individual production tanks: ∀p ∈ P, t ∈ T
+For individual production tanks: \forall p \in P, t \in T
 
 .. math::
 
-    ∑_{(p,a)∈PAL}\textcolor{red}{F_{p,a,t}^{Drain}} =\textcolor{red}{B_{p,t}^{Production}}
+    \sum\nolimits_{-}{(p,a)\in PAL}\textcolor{red}{F_{p,a,t}^{Drain}} =\textcolor{red}{B_{p,t}^{Production}}
 
 
 Otherwise, if the production tanks are equalized, the production water drained is measured on an aggregated production pad level.
 
-For equalized production tanks: ∀p ∈ P, t ∈ T
+For equalized production tanks: \forall p \in P, t \in T
 
 .. math::
 
@@ -541,47 +541,47 @@ For equalized production tanks: ∀p ∈ P, t ∈ T
 
 
 
-**Production Pad Supply Balance:** ∀p ∈ PP, t ∈ T
+**Production Pad Supply Balance:** :math:`\forall p \in PP, t \in T`
 
 All produced water must be accounted for. For each production pad and for each time period, the volume of outgoing water must be equal to the produced water transported out of the production pad.
 
 .. math::
 
-    \textcolor{red}{B_{p,t}^{Production}} = ∑_{(p,n)∈PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈PPA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{red}{B_{p,t}^{Production}} = \sum\nolimits_{-}{(p,n)\in PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in PPA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,k)∈PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,k)\in PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,r)∈PRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,o)∈POT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\textcolor{red}{S_{p,t}^{Production}}
+        +\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,o)\in POT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\textcolor{red}{S_{p,t}^{Production}}
 
 
 
-**Completions Pad Supply Balance (i.e. Flowback Balance):** ∀p ∈ CP, t ∈ T
+**Completions Pad Supply Balance (i.e. Flowback Balance):** :math:`\forall p \in CP, t \in T`
 
 All flowback water must be accounted for.  For each completions pad and for each time period, the volume of outgoing water must be equal to the forecasted flowback produced water for the completions pad.
 
 .. math::
 
-    \textcolor{green}{β_{p,t}^{Flowback}} = ∑_{(p,n)∈CNA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+
+    \textcolor{green}{\beta_{p,t}^{Flowback}} = \sum\nolimits_{-}{(p,n)\in CNA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+
 
-    ∑_{(p,k)∈CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,r)∈CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{S_{p,t}^{Flowback}}
+    \sum\nolimits_{-}{(p,k)\in CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{S_{p,t}^{Flowback}}
 
 
 
-**Network Node Balance:** ∀n ∈ N, t ∈ T
+**Network Node Balance:** :math:`\forall n \in N, t \in T`
 
 Flow balance constraint (i.e., inputs are equal to outputs). For each pipeline node and for each time period, the volume water into the node is equal to the volume of water out of the node.
 
 .. math::
 
-    ∑_{(p,n)∈PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,n)∈CNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n ̃,n)∈NNA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,n)∈SNA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \sum\nolimits_{-}{(p,n)\in PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,n)\in CNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n TILDETILDETILDE,n)\in NNA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        = ∑_{(n,n ̃ )∈NNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(n,k)∈NKA}\textcolor{red}{F_{l,l,t}^{Piped}}
+        = \sum\nolimits_{-}{(n,n TILDETILDETILDE )\in NNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(n,k)\in NKA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(n,r)∈NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n,s)∈NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n,o)∈NOA}\textcolor{red}{F_{l,l,t}^{Piped}}
+        +\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,o)\in NOA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
 
 
-**Bi-Directional Flow:** ∀(l,l) ∈ {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, t ∈ T
+**Bi-Directional Flow:** :math:`\forall (l,l) \in {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, t \in T`
 
 There can only be flow in one direction for a given pipeline arc in a given time period.
 
@@ -589,39 +589,37 @@ Flow is only allowed in a given direction if the binary indicator for that direc
 
 .. math::
 
-    \textcolor{red}{y_{l,l ̃,t}^{Flow}}+\textcolor{red}{y_{l ̃,l,t}^{Flow}} = 1
+    \textcolor{red}{y_{l,\tilde{l},t}^{Flow}}+\textcolor{red}{y_{\tilde{l},l,t}^{Flow}} = 1
 
 .. note:: Technically this constraint should only be enforced for truly reversible arcs (e.g. NCA and CNA); and even then it only needs to be defined per one reversible arc (e.g. NCA only and not NCA and CNA).
 
 .. math::
 
-    \textcolor{red}{F_{l,l,t}^{Piped}}≤\textcolor{red}{y_{l,l,t}^{Flow}}⋅\textcolor{green}{M^{Flow}}
+    \textcolor{red}{F_{l,l,t}^{Piped}}≤\textcolor{red}{y_{l,l,t}^{Flow}} \cdot \textcolor{green}{M^{Flow}}
 
 
 
-**Storage Site Balance:** ∀s ∈ S, t ∈ T
+**Storage Site Balance:** :math:`\forall s \in S, t \in T`
 
 For each storage site and for each time period, if it is the first time period, the storage level is the initial storage. Otherwise, the storage level is equal to the storage level in the previous time period plus water inputs minus water outputs.
 
 .. math::
 
-    \textcolor{red}{L_{s,t}^{Storage}} = \textcolor{green}{λ_{s,t=1}^{Storage}}+\textcolor{red}{L_{s,t-1}^{Storage}}+∑_{(n,s)∈NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \textcolor{red}{L_{s,t}^{Storage}} = \textcolor{green}{\lambda_{s,t=1}^{Storage}}+\textcolor{red}{L_{s,t-1}^{Storage}}+\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}}-∑_{(s,n)∈SNA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,k)∈SKA}\textcolor{red}{F_{l,l,t}^{Piped}}
+        +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}}-\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        -∑_{(s,r)∈SRA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,o)∈SOA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}}-∑_{(s,k)∈SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        -\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}}-\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
 
 
-**Pipeline Capacity:**
-
-∀(l,l) ∈ {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, [t ∈ T]
+**Pipeline Capacity:** :math:`\forall (l,l) \in {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, [t \in T]`
 
 .. math::
 
-    \textcolor{red}{F_{l,l,[t]}^{Capacity}} = \textcolor{green}{σ_{l,l}^{Pipeline}}+\textcolor{red}{S_{l,l}^{PipelineCapacity}}
+    \textcolor{red}{F_{l,l,[t]}^{Capacity}} = \textcolor{green}{\sigma_{l,l}^{Pipeline}}+\textcolor{red}{S_{l,l}^{PipelineCapacity}}
 
-∀(l,l) ∈ {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, t ∈ T
+\forall (l,l) \in {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, t \in T
 
 .. math::
 
@@ -633,13 +631,13 @@ For each storage site and for each time period, if it is the first time period, 
 
 The total stored water in a given time period must be less than the capacity. If the storage capacity limits the feasibility, the slack variable will be nonzero, and the storage capacity will be increased to allow a feasible solution.
 
-∀s ∈ S,[t ∈ T]
+\forall s \in S,[t \in T]
 
 .. math::
 
-    \textcolor{red}{X_{s,[t]}^{Capacity}} = \textcolor{green}{σ_{s}^{Storage}}+\textcolor{red}{S_{s}^{StorageCapacity}}
+    \textcolor{red}{X_{s,[t]}^{Capacity}} = \textcolor{green}{\sigma_{s}^{Storage}}+\textcolor{red}{S_{s}^{StorageCapacity}}
 
-∀s ∈ S, t ∈ T
+\forall s \in S, t \in T
 
 .. math::
 
@@ -651,29 +649,29 @@ The total stored water in a given time period must be less than the capacity. If
 
 The total disposed water in a given time period must be less than the capacity. If the disposal capacity limits the feasibility, the slack variable will be nonzero, and the disposal capacity will be increased to allow a feasible solution.
 
-∀k ∈ K, [t ∈ T]
+\forall k \in K, [t \in T]
 
 .. math::
 
-    \textcolor{red}{D_{k,[t]}^{Capacity}} = \textcolor{green}{σ_{k}^{Disposal}}+\textcolor{red}{S_{k}^{DisposalCapacity}}
+    \textcolor{red}{D_{k,[t]}^{Capacity}} = \textcolor{green}{\sigma_{k}^{Disposal}}+\textcolor{red}{S_{k}^{DisposalCapacity}}
 
-∀k ∈ K, t ∈ T
-
-.. math::
-
-
-    ∑_{(n,k)∈NKA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,k)∈SKA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,k)∈SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,k)∈PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
-
-        +∑_{(p,k)∈CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(r,k)∈RKT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{red}{D_{k,[t]}^{Capacity}}
-
-∀k ∈ K, t ∈ T
+\forall k \in K, t \in T
 
 .. math::
 
 
-    ∑_{(n,k)∈NKA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,k)∈SKA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,k)∈SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,k)∈PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(n,k)\in NKA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,k)\in PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,k)∈CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(r,k)∈RKT}\textcolor{red}{F_{l,l,t}^{Trucked}} =\textcolor{red}{F_{k,t}^{DisposalDestination}}
+        +\sum\nolimits_{-}{(p,k)\in CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(r,k)\in RKT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{red}{D_{k,[t]}^{Capacity}}
+
+\forall k \in K, t \in T
+
+.. math::
+
+
+    \sum\nolimits_{-}{(n,k)\in NKA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,k)\in PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+
+        +\sum\nolimits_{-}{(p,k)\in CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(r,k)\in RKT}\textcolor{red}{F_{l,l,t}^{Trucked}} =\textcolor{red}{F_{k,t}^{DisposalDestination}}
 
 
 
@@ -681,155 +679,155 @@ The total disposed water in a given time period must be less than the capacity. 
 
 The total treated water in a given time period must be less than the capacity. If the treatment capacity limits the feasibility, the slack variable will be nonzero, and the treatment capacity will be increased to allow a feasible solution.
 
-∀r ∈ R, t ∈ T
+\forall r \in R, t \in T
 
 .. math::
 
-    ∑_{(n,r)∈NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,r)∈SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,r)∈PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(n,r)\in NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,r)∈CRT}\textcolor{red}{F_{l,l,t}^{Trucked}}≤\textcolor{green}{σ_{r}^{Treatment}}+\textcolor{red}{S_{r}^{TreatmentCapacity}}
+        +\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{red}{F_{l,l,t}^{Trucked}}≤\textcolor{green}{\sigma_{r}^{Treatment}}+\textcolor{red}{S_{r}^{TreatmentCapacity}}
 
-∀r ∈ R, t ∈ T
+\forall r \in R, t \in T
 
 .. math::
 
-    ∑_{(n,r)∈NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,r)∈SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,r)∈PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(n,r)\in NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,r)∈CRT}\textcolor{red}{F_{l,l,t}^{Trucked}}=\textcolor{red}{F_{r,t}^{TreatmentDestination}}
+        +\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{red}{F_{l,l,t}^{Trucked}}=\textcolor{red}{F_{r,t}^{TreatmentDestination}}
 
 
 **Beneficial Reuse Capacity:**
 
 The total water for beneficial reuse in a given time period must be less than the capacity. If the beneficial reuse capacity limits the feasibility, the slack variable will be nonzero, and the beneficial reuse capacity will be increased to allow a feasible solution.
 
-∀o ∈ O, t ∈ T
+\forall o \in O, t \in T
 
 .. math::
 
-    ∑_{(n,o)∈NOA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,o)∈SOA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,o)∈POT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{o}^{Reuse}}+\textcolor{red}{S_{o}^{ReuseCapacity}}
+    \sum\nolimits_{-}{(n,o)\in NOA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,o)\in POT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{o}^{Reuse}}+\textcolor{red}{S_{o}^{ReuseCapacity}}
 
-∀o ∈ O, t ∈ T
+\forall o \in O, t \in T
 
 .. math::
 
-    ∑_{(n,o)∈NOA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,o)∈SOA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,o)∈POT}\textcolor{red}{F_{l,l,t}^{Trucked}} =\textcolor{red}{F_{o,t}^{BeneficialReuseDestination}}
+    \sum\nolimits_{-}{(n,o)\in NOA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,o)\in POT}\textcolor{red}{F_{l,l,t}^{Trucked}} =\textcolor{red}{F_{o,t}^{BeneficialReuseDestination}}
 
 
-**Fresh Sourcing Cost:**  ∀f ∈ F, p ∈ CP, t ∈ T
+**Fresh Sourcing Cost:** :math:`\forall f \in F, p \in CP, t \in T`
 
 For each freshwater source, for each completions pad, and for each time period, the freshwater sourcing cost is equal to all output from the freshwater source times the freshwater sourcing cost.
 
 .. math::
 
-    \textcolor{red}{C_{f,p,t}^{Sourced}} =(\textcolor{red}{F_{f,p,t}^{Sourced}}+\textcolor{red}{F_{f,p,t}^{Trucked}})⋅\textcolor{green}{π_{f}^{Sourcing}}
+    \textcolor{red}{C_{f,p,t}^{Sourced}} =(\textcolor{red}{F_{f,p,t}^{Sourced}}+\textcolor{red}{F_{f,p,t}^{Trucked}}) \cdot \textcolor{green}{π_{f}^{Sourcing}}
 
-    \textcolor{red}{C^{TotalSourced}} = ∑_{∀t∈T}∑_{(f,p)∈FCA}\textcolor{red}{C_{f,p,t}^{Sourced}}
+    \textcolor{red}{C^{TotalSourced}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{(f,p)\in FCA}\textcolor{red}{C_{f,p,t}^{Sourced}}
 
 
 
-**Disposal Cost:** ∀k ∈ K, t ∈ T
+**Disposal Cost:** :math:`\forall k \in K, t \in T`
 
 For each disposal site, for each time period, the disposal cost is equal to all water moved into the disposal site multiplied by the operational disposal cost. Total disposal cost is the sum of disposal costs over all time periods and all disposal sites.
 
 .. math::
 
-       \textcolor{red}{C_{k,t}^{Disposal}} = (∑_{(l,l)∈{NKA,RKA,SKA}}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(l,l)∈{PKT,CKT,SKT,RKT}}\textcolor{red}{F_{l,l,t}^{Trucked}})⋅ \textcolor{green}{π_{k}^{Disposal}}
+       \textcolor{red}{C_{k,t}^{Disposal}} = (\sum\nolimits_{-}{(l,l)\in {NKA,RKA,SKA}}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(l,l)\in {PKT,CKT,SKT,RKT}}\textcolor{red}{F_{l,l,t}^{Trucked}}) \cdot \textcolor{green}{π_{k}^{Disposal}}
 
-       \textcolor{red}{C^{TotalDisposal}} = ∑_{∀t∈T}∑_{k∈K}\textcolor{red}{C_{k,t}^{Disposal}}
+       \textcolor{red}{C^{TotalDisposal}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{k\in K}\textcolor{red}{C_{k,t}^{Disposal}}
 
 
 
-**Treatment Cost:** ∀r ∈ R, t ∈ T
+**Treatment Cost:** :math:`\forall r \in R, t \in T`
 
 For each treatment site, for each time period, the treatment cost is equal to all water moved to the treatment site multiplied by the operational treatment cost. The total treatments cost is the sum of treatment costs over all time periods and all treatment sites.
 
 .. math::
 
-    \textcolor{red}{C_{r,t}^{Treatment}} = (∑_{(l,l)∈{NRA,SRA}}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(l,l)∈{PRT,CRT}}\textcolor{red}{F_{l,l,t}^{Trucked}})⋅ \textcolor{green}{π_{r}^{Treatment}}
+    \textcolor{red}{C_{r,t}^{Treatment}} = (\sum\nolimits_{-}{(l,l)\in {NRA,SRA}}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(l,l)\in {PRT,CRT}}\textcolor{red}{F_{l,l,t}^{Trucked}}) \cdot \textcolor{green}{π_{r}^{Treatment}}
 
-    \textcolor{red}{C^{TotalTreatment}} = ∑_{∀t∈T}∑_{r∈R}\textcolor{red}{C_{r,t}^{Treatment}}
+    \textcolor{red}{C^{TotalTreatment}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{r\in R}\textcolor{red}{C_{r,t}^{Treatment}}
 
 
 
-**Treatment Balance:** ∀r ∈ R, t ∈ T
+**Treatment Balance:** :math:`\forall r \in R, t \in T`
 
 Water input into treatment facility is treated with a level of efficiency, meaning only a given percentage of the water input is outputted to be reused at the completions pads.
 
 .. math::
 
-    \textcolor{green}{ϵ^{Treatment}}⋅(∑_{(n,r)∈NRA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,r)∈SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,r)∈PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \textcolor{green}{\varepsilon^{Treatment}} \cdot (\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,r)∈CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} )=∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} + \textcolor{red}{F_{r,t}^{UnusedTreatedWater}}
+        +\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} )=\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} + \textcolor{red}{F_{r,t}^{UnusedTreatedWater}}
 
-where :math:`\textcolor{green}{ϵ^{Treatment}}` <1
+where :math:`\textcolor{green}{\varepsilon^{Treatment}}` \le1
 
 
 
-**Completions Reuse Cost:** ∀p ∈ P, t ∈ T
+**Completions Reuse Cost:** :math:`\forall p \in P, t \in T`
 
 Completions reuse water is all water that meets completions pad demand, excluding freshwater. Completions reuse cost is the volume of completions reused water multiplied by the cost for reuse.
 
 .. math::
 
-    \textcolor{red}{C_{p,t}^{CompletionsReuse}} = (∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{red}{C_{p,t}^{CompletionsReuse}} = (\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}})⋅ \textcolor{green}{π_{p}^{CompletionsReuse}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}}) \cdot \textcolor{green}{π_{p}^{CompletionsReuse}}
 
 
 .. note:: Freshwater sourcing is excluded from completions reuse costs.
 
 .. math::
 
-    \textcolor{red}{C^{TotalCompletionsReuse}} = ∑_{∀t∈T}∑_{p∈CP}\textcolor{red}{C_{p,t}^{CompletionsReuse}}
+    \textcolor{red}{C^{TotalCompletionsReuse}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{p\in CP}\textcolor{red}{C_{p,t}^{CompletionsReuse}}
 
 
 
-**Piping Cost:** ∀(l,l) ∈ {PPA,…,CCA}, t ∈ T
+**Piping Cost:** :math:`\forall (l,l) \in {PPA,…,CCA}, t \in T`
 
 Piping cost is the total volume of piped water multiplied by the cost for piping.
 
 .. math::
 
-    \textcolor{red}{C_{l,l,t}^{Piped}} = (\textcolor{red}{F_{l,l,t}^{Piped}}+\textcolor{red}{F_{l,l,t}^{Sourced}})⋅ \textcolor{green}{π_{l,l}^{Pipeline}}
+    \textcolor{red}{C_{l,l,t}^{Piped}} = (\textcolor{red}{F_{l,l,t}^{Piped}}+\textcolor{red}{F_{l,l,t}^{Sourced}}) \cdot \textcolor{green}{π_{l,l}^{Pipeline}}
 
-    \textcolor{red}{C^{TotalPiping}} = ∑_({t∈T}∑_{∀(l,l)∈{PPA,…}}\textcolor{red}{C_{l,l,t}^{Piped}}
+    \textcolor{red}{C^{TotalPiping}} = \sum\nolimits_{-}({t\in T}\sum\nolimits_{-}{\forall (l,l)\in {PPA,…}}\textcolor{red}{C_{l,l,t}^{Piped}}
 
 
 .. note:: The constraints above explicitly consider freshwater piping via FCA arcs.
 
 
 
-**Storage Deposit Cost:** ∀s ∈ S, t ∈ T
+**Storage Deposit Cost:** :math:`\forall s \in S, t \in T`
 
 Cost of depositing into storage is equal to the total volume of water moved into storage multiplied by the storage operation cost rate.
 
 .. math::
 
-    \textcolor{red}{C_{s,t}^{Storage}} = (∑_{(l,l)∈{NSA}}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(l,l)∈{CST}}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(l,s)∈{PST}}\textcolor{red}{F_{l,s,t}^{Trucked}})⋅ \textcolor{green}{π_{s}^{Storage}}
+    \textcolor{red}{C_{s,t}^{Storage}} = (\sum\nolimits_{-}{(l,l)\in {NSA}}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(l,l)\in {CST}}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(l,s)\in {PST}}\textcolor{red}{F_{l,s,t}^{Trucked}}) \cdot \textcolor{green}{π_{s}^{Storage}}
 
-    \textcolor{red}{C^{TotalStorage}} = ∑_{∀t∈T}∑_{∀s∈S}\textcolor{red}{C_{s,t}^{Storage}}
+    \textcolor{red}{C^{TotalStorage}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall s\in S}\textcolor{red}{C_{s,t}^{Storage}}
 
 
 
-**Storage Withdrawal Credit:** ∀s ∈ S, t ∈ T
+**Storage Withdrawal Credit:** :math:`\forall s \in S, t \in T`
 
 Credits from withdrawing from storage is equal to the total volume of water moved out from storage multiplied by the storage operation credit rate.
 
 .. math::
 
-    \textcolor{red}{R_{s,t}^{Storage}} = (∑_{(l,l)∈{SNA,SCA,SKA,SRA,SOA}}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(l,l)∈{SCT,SKT}}\textcolor{red}{F_{l,l,t}^{Trucked}})⋅ \textcolor{green}{ρ_{s}^{Storage}}
+    \textcolor{red}{R_{s,t}^{Storage}} = (\sum\nolimits_{-}{(l,l)\in {SNA,SCA,SKA,SRA,SOA}}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(l,l)\in {SCT,SKT}}\textcolor{red}{F_{l,l,t}^{Trucked}}) \cdot \textcolor{green}{\rho_{s}^{Storage}}
 
-    \textcolor{red}{R^{TotalStorage}} = ∑_{∀t∈T}∑_{∀s∈S}\textcolor{red}{R_{s,t}^{Storage}}
+    \textcolor{red}{R^{TotalStorage}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall s\in S}\textcolor{red}{R_{s,t}^{Storage}}
 
 
 
-**Pad Storage Cost:** ∀l ∈ L, l ̃ ∈ L, t ∈ T
+**Pad Storage Cost:** :math:`\forall l \in L, \tilde{l}\in L, t \in T`
 
 .. math::
 
-    \textcolor{red}{C^{TotalPadStorage}} = ∑_{∀t∈T}∑_{∀p∈CP}\textcolor{red}{z_{p,t}^{PadStorage}}⋅\textcolor{green}{π_{p,t}^{PadStorage}}
+    \textcolor{red}{C^{TotalPadStorage}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall p\in CP}\textcolor{red}{z_{p,t}^{PadStorage}} \cdot \textcolor{green}{π_{p,t}^{PadStorage}}
 
 
 **Trucking Cost (Simplified)**
@@ -838,9 +836,9 @@ Trucking cost between two locations for time period is equal to the trucking vol
 
 .. math::
 
-    \textcolor{red}{C_{l,l ̃  ,t}^{Trucked}} = \textcolor{red}{F_{l,l ̃,t}^{Trucked}}⋅\textcolor{green}{1⁄δ^{Truck}}⋅\textcolor{green}{τ_{p,p}^{Trucking}}⋅\textcolor{green}{π_{l}^{Trucking}}
+    \textcolor{red}{C_{l,\tilde{l},t}^{Trucked}} = \textcolor{red}{F_{l,\tilde{l},t}^{Trucked}} \cdot \textcolor{green}{1/\delta^{Truck}} \cdot \textcolor{green}{\tau_{p,p}^{Trucking}} \cdot \textcolor{green}{π_{l}^{Trucking}}
 
-    \textcolor{red}{C^{TotalTrucking}} = ∑_{∀t∈T}∑_{∀(l,l)∈{PPA,…,CCT}}\textcolor{red}{C_{l,l ̃  ,t}^{Trucked}}
+    \textcolor{red}{C^{TotalTrucking}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall (l,l)\in {PPA,…,CCT}}\textcolor{red}{C_{l,\tilde{l},t}^{Trucked}}
 
 
 .. note:: The constraints above explicitly consider freshwater trucking via FCT arcs.
@@ -853,13 +851,13 @@ Weighted sum of the slack variables. In the case that the model is infeasible, t
 
 .. math::
 
-    \textcolor{red}{C^{Slack}} = ∑_{p∈CP}∑_{t∈T}\textcolor{red}{S_{p,t}^{FracDemand}}⋅\textcolor{green}{ψ^{FracDemand}}+∑_{p∈PP}∑_{t∈T}\textcolor{red}{S_{p,t}^{Production}} ⋅\textcolor{green}{ψ^{Production}}
+    \textcolor{red}{C^{Slack}} = \sum\nolimits_{-}{p\in CP}\sum\nolimits_{-}{t\in T}\textcolor{red}{S_{p,t}^{FracDemand}} \cdot \textcolor{green}{\psi^{FracDemand}}+\sum\nolimits_{-}{p\in PP}\sum\nolimits_{-}{t\in T}\textcolor{red}{S_{p,t}^{Production}} \cdot \textcolor{green}{\psi^{Production}}
 
-        +∑_{p∈CP}∑_{t∈T}\textcolor{red}{S_{p,t}^{Flowback}}⋅\textcolor{green}{ψ^{Flowback}}+∑_{(l,l)∈{…}}\textcolor{red}{S_{l,l}^{PipelineCapacity}} ⋅\textcolor{green}{ψ^{PipeCapacity}}
+        +\sum\nolimits_{-}{p\in CP}\sum\nolimits_{-}{t\in T}\textcolor{red}{S_{p,t}^{Flowback}} \cdot \textcolor{green}{\psi^{Flowback}}+\sum\nolimits_{-}{(l,l)\in {…}}\textcolor{red}{S_{l,l}^{PipelineCapacity}} \cdot \textcolor{green}{\psi^{PipeCapacity}}
 
-         +∑_{s∈S}\textcolor{red}{S_{s}^{StorageCapacity}} ⋅\textcolor{green}{ψ^{StorageCapacity}}+∑_{k∈K}\textcolor{red}{S_{k}^{DisposalCapacity}}⋅\textcolor{green}{ψ^{DisposalCapacity}}
+         +\sum\nolimits_{-}{s\in S}\textcolor{red}{S_{s}^{StorageCapacity}} \cdot \textcolor{green}{\psi^{StorageCapacity}}+\sum\nolimits_{-}{k\in K}\textcolor{red}{S_{k}^{DisposalCapacity}} \cdot \textcolor{green}{\psi^{DisposalCapacity}}
 
-         +∑_{r∈R}\textcolor{red}{S_{r}^{TreatmentCapacity}} ⋅\textcolor{green}{ψ^{TreatmentCapacity}}+∑_{o∈O}\textcolor{red}{S_{o}^{BeneficialReuseCapacity}} ⋅\textcolor{green}{ψ^{BeneficialReuseCapacity}}
+         +\sum\nolimits_{-}{r\in R}\textcolor{red}{S_{r}^{TreatmentCapacity}} \cdot \textcolor{green}{\psi^{TreatmentCapacity}}+\sum\nolimits_{-}{o\in O}\textcolor{red}{S_{o}^{BeneficialReuseCapacity}} \cdot \textcolor{green}{\psi^{BeneficialReuseCapacity}}
 
 .. _operational_model_water_quality_extension:
 
@@ -878,14 +876,14 @@ Assumptions:
 
 **Water Quality Sets**
 
-:math:`\textcolor{blue}{w ∈ W}`			 Water Quality Components (e.g., TDS)
+:math:`\textcolor{blue}{w \in W}`			 Water Quality Components (e.g., TDS)
 
 
 **Water Quality Parameters**
 
 :math:`\textcolor{green}{v_{l,w,[t]}}` = 	   Water quality at well pad
 
-:math:`\textcolor{green}{ξ_{l,w}}` = 	       Initial water quality at storage
+:math:`\textcolor{green}{\xi_{l,w}}` = 	       Initial water quality at storage
 
 
 **Water Quality Variables**
@@ -893,74 +891,74 @@ Assumptions:
 :math:`\textcolor{red}{Q_{l,w,t}}` =           Water quality at location
 
 
-**Disposal Site Water Quality** ∀k ∈ K, w ∈ W, t ∈ T
+**Disposal Site Water Quality** :math:`\forall k \in K, w \in W, t \in T`
 
 The water quality of disposed water is dependent on the flow rates into the disposal site and the quality of each of these flows.
 
 .. math::
 
-    ∑_{(n,k)∈NKA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}} +∑_{(s,k)∈SKA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}}+∑_{(r,k)∈RKA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{r,w,t}}
+    \sum\nolimits_{-}{(n,k)\in NKA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}} +\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}}+\sum\nolimits_{-}{(r,k)\in RKA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{r,w,t}}
 
-    +∑_{(s,k)∈SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{s,w,t}}+∑_{(p,k)∈PKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{p,w,t}}
+    +\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{s,w,t}}+\sum\nolimits_{-}{(p,k)\in PKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{p,w,t}}
 
-    +∑_{(p,k)∈CKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{p,w,t}}+∑_{(r,k)∈RKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{r,w,t}}
+    +\sum\nolimits_{-}{(p,k)\in CKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{p,w,t}}+\sum\nolimits_{-}{(r,k)\in RKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{r,w,t}}
 
-    =\textcolor{purple}{F_{k,t}^{DisposalDestination}}⋅\textcolor{red}{Q_{k,w,t}}
+    =\textcolor{purple}{F_{k,t}^{DisposalDestination}} \cdot \textcolor{red}{Q_{k,w,t}}
 
-**Storage Site Water Quality** ∀s ∈ S, w ∈ W, t ∈ T
+**Storage Site Water Quality** :math:`\forall s \in S, w \in W, t \in T`
 
 The water quality at storage sites is dependent on the flow rates into the storage site, the volume of water in storage in the previous time period, and the quality of each of these flows. Even mixing is assumed, so all outgoing flows have the same water quality. If it is the first time period, the initial storage level and initial water quality replaces the water stored and water quality in the previous time period respectively.
 
 .. math::
 
-    \textcolor{green}{λ_{s,t=1}^{Storage}}⋅\textcolor{green}{ξ_{s,w}} +\textcolor{purple}{L_{s,t-1}^{Storage}}⋅\textcolor{red}{Q_{s,w,t-1}} +∑_{(n,s)∈NSA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}}
+    \textcolor{green}{\lambda_{s,t=1}^{Storage}} \cdot \textcolor{green}{\xi_{s,w}} +\textcolor{purple}{L_{s,t-1}^{Storage}} \cdot \textcolor{red}{Q_{s,w,t-1}} +\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}}
 
-    +∑_{(p,s)∈PST}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{p,w,t}} +∑_{(p,s)∈CST}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{p,w,t}}
+    +\sum\nolimits_{-}{(p,s)\in PST}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{p,w,t}} +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{p,w,t}}
 
-    = \textcolor{red}{Q_{s,w,t}}⋅(\textcolor{purple}{L_{s,t}^{Storage}} +∑_{(s,n)∈SNA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,p)∈SCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,k)∈SKA}\textcolor{purple}{F_{l,l,t}^{Piped}}
+    = \textcolor{red}{Q_{s,w,t}} \cdot (\textcolor{purple}{L_{s,t}^{Storage}} +\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{purple}{F_{l,l,t}^{Piped}}
 
-    +∑_{(s,r)∈SRA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,o)∈SOA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,p)∈SCT}\textcolor{purple}{F_{l,l,t}^{Trucked}}+∑_{(s,k)∈SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}})
+    +\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{purple}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}})
 
-**Treatment Site Water Quality** ∀r ∈ R, w ∈ W, t ∈ T
+**Treatment Site Water Quality** :math:`\forall r \in R, w \in W, t \in T`
 
 The water quality at treatment sites is dependent on the flow rates into the treatment site, the efficiency of treatment, and the water quality of the flows. Even mixing is assumed, so all outgoing flows have the same water quality. The treatment process does not affect water quality
 
 .. math::
 
-    \textcolor{green}{ϵ_{r,w}^{Treatment}}⋅(∑_{(n,r)∈NRA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}} +∑_{(s,r)∈SRA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}}
+    \textcolor{green}{\varepsilon_{r,w}^{Treatment}} \cdot (\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}} +\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}}
 
-    +∑_{(p,r)∈PRT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{p,w,t}} +∑_{(p,r)∈CRT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{p,w,t}} )
+    +\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{p,w,t}} +\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{p,w,t}} )
 
-    = \textcolor{red}{Q_{r,w,t}}⋅(∑_{(r,p)∈RCA}\textcolor{purple}{F_{l,l,t}^{Piped}} + \textcolor{purple}{F_{r,t}^{UnusedTreatedWater}})
+    = \textcolor{red}{Q_{r,w,t}} \cdot (\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{purple}{F_{l,l,t}^{Piped}} + \textcolor{purple}{F_{r,t}^{UnusedTreatedWater}})
 
-where :math:`\textcolor{green}{ϵ_{r,w}^{Treatment}}` <1
+where :math:`\textcolor{green}{\varepsilon_{r,w}^{Treatment}}` \le1
 
-**Network Node Water Quality** ∀n ∈ N, w ∈ W, t ∈ T
+**Network Node Water Quality** :math:`\forall n \in N, w \in W, t \in T`
 
 The water quality at nodes is dependent on the flow rates into the node and the water quality of the flows. Even mixing is assumed, so all outgoing flows have the same water quality.
 
 .. math::
 
-    ∑_{(p,n)∈PNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{p,w,t}} +∑_{(p,n)∈CNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{p,w,t}}
+    \sum\nolimits_{-}{(p,n)\in PNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{p,w,t}} +\sum\nolimits_{-}{(p,n)\in CNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{p,w,t}}
 
-    +∑_{(n ̃,n)∈NNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}}+∑_{(s,n)∈SNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}}
+    +\sum\nolimits_{-}{(n TILDETILDETILDE,n)\in NNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}}+\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}}
 
-    = \textcolor{red}{Q_{n,w,t}}⋅(∑_{(n,n ̃)∈NNA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(n,p)∈NCA}\textcolor{purple}{F_{l,l,t}^{Piped}}
+    = \textcolor{red}{Q_{n,w,t}} \cdot (\sum\nolimits_{-}{(n,n TILDETILDETILDE)\in NNA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{purple}{F_{l,l,t}^{Piped}}
 
-    +∑_{(n,k)∈NKA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(n,r)∈NRA}\textcolor{purple}{F_{l,l,t}^{Piped}}
+    +\sum\nolimits_{-}{(n,k)\in NKA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{purple}{F_{l,l,t}^{Piped}}
 
-    +∑_{(n,s)∈NSA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(n,o)∈NOA}\textcolor{purple}{F_{l,l,t}^{Piped}})
+    +\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,o)\in NOA}\textcolor{purple}{F_{l,l,t}^{Piped}})
 
 
-**Beneficial Reuse Water Quality** ∀o ∈ O, w ∈ W, t ∈ T
+**Beneficial Reuse Water Quality** :math:`\forall o \in O, w \in W, t \in T`
 
 The water quality at beneficial reuse sites is dependent on the flow rates into the site and the water quality of the flows.
 
 .. math::
 
-    ∑_{(n,o)∈NOA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}} +∑_{(s,o)∈SOA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}} +∑_{(p,o)∈POT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{p,w,t}}
+    \sum\nolimits_{-}{(n,o)\in NOA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}} +\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}} +\sum\nolimits_{-}{(p,o)\in POT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{p,w,t}}
 
-    = \textcolor{red}{Q_{o,w,t}}⋅\textcolor{purple}{F_{o,t}^{BeneficialReuseDestination}}
+    = \textcolor{red}{Q_{o,w,t}} \cdot \textcolor{purple}{F_{o,t}^{BeneficialReuseDestination}}
 
 
 .. _model_terminology:

--- a/docs/model_library/strategic_water_management/index.rst
+++ b/docs/model_library/strategic_water_management/index.rst
@@ -28,105 +28,105 @@ Strategic Model Mathematical Notation
 
 **Sets**
 
-:math:`\textcolor{blue}{t ∈ T}`			                               Time periods (i.e. days)
+:math:`\textcolor{blue}{t \in T}`			                               Time periods (i.e. days)
 
-:math:`\textcolor{blue}{p ∈ P}`			                               Well pads
+:math:`\textcolor{blue}{p \in P}`			                               Well pads
 
-:math:`\textcolor{blue}{p ∈ PP}`			                           Production pads (subset of well pads P)
+:math:`\textcolor{blue}{p \in PP}`			                           Production pads (subset of well pads P)
 
-:math:`\textcolor{blue}{p ∈ CP}`		                               Completions pads (subset of well pads P)
+:math:`\textcolor{blue}{p \in CP}`		                               Completions pads (subset of well pads P)
 
-:math:`\textcolor{blue}{f ∈ F}`			                               Freshwater sources
+:math:`\textcolor{blue}{f \in F}`			                               Freshwater sources
 
-:math:`\textcolor{blue}{k ∈ K}`			                               Disposal sites
+:math:`\textcolor{blue}{k \in K}`			                               Disposal sites
 
-:math:`\textcolor{blue}{s ∈ S}`			                               Storage sites
+:math:`\textcolor{blue}{s \in S}`			                               Storage sites
 
-:math:`\textcolor{blue}{r ∈ R}`			                               Treatment sites
+:math:`\textcolor{blue}{r \in R}`			                               Treatment sites
 
-:math:`\textcolor{blue}{o ∈ O}`			                               Beneficial Reuse options
+:math:`\textcolor{blue}{o \in O}`			                               Beneficial Reuse options
 
-:math:`\textcolor{blue}{n ∈ N}`			                               Network nodes
+:math:`\textcolor{blue}{n \in N}`			                               Network nodes
 
-:math:`\textcolor{blue}{l ∈ L}`			                               Locations (superset of well pads, disposal sites, nodes, …)
+:math:`\textcolor{blue}{l \in L}`			                               Locations (superset of well pads, disposal sites, nodes, …)
 
-:math:`\textcolor{blue}{d ∈ D}`			                               Pipeline Diameters
+:math:`\textcolor{blue}{d \in D}`			                               Pipeline Diameters
 
-:math:`\textcolor{blue}{c ∈ C}`				                           Storage capacities
+:math:`\textcolor{blue}{c \in C}`				                           Storage capacities
 
-:math:`\textcolor{blue}{j ∈ J}`				                           Treatment capacities
+:math:`\textcolor{blue}{j \in J}`				                           Treatment capacities
 
-:math:`\textcolor{blue}{i ∈ I}`				                           Injection (i.e. disposal) capacities
-
-
-:math:`\textcolor{blue}{(p,p) ∈ PCA}`	                               Production-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(p,n) ∈ PNA}`                                 Production-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(p,p) ∈ PPA}`                                 Production-to-production pipeline arcs
-
-:math:`\textcolor{blue}{(p,n) ∈ CNA}`	                               Completions-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(p,p) ∈ CCA}`	                               Completions-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(n,n) ∈ NNA}`                                 Node-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(n,p) ∈ NCA}`                                 Node-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(n,k) ∈ NKA}`	                               Node-to-disposal pipeline arcs
-
-:math:`\textcolor{blue}{(n,s) ∈ NSA}`	                               Node-to-storage pipeline arcs
-
-:math:`\textcolor{blue}{(n,r) ∈ NRA}`                                 Node-to-treatment pipeline arcs
-
-:math:`\textcolor{blue}{(n,o) ∈ NOA}`	                               Node-to-beneficial reuse pipeline arcs
-
-:math:`\textcolor{blue}{(f,p) ∈ FCA}`	                               Freshwater-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(r,n) ∈ RNA}`	                               Treatment-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(r,p) ∈ RCA}`	                               Treatment-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(r,k) ∈ RKA}`	                               Treatment-to-disposal pipeline arcs
-
-:math:`\textcolor{blue}{(r,s) ∈ RSA}`			                       Treatment-to-storage pipeline arcs
-
-:math:`\textcolor{blue}{(s,n) ∈ SNA}`	                               Storage-to-node pipeline arcs
-
-:math:`\textcolor{blue}{(s,p) ∈ SCA}`	                               Storage-to-completions pipeline arcs
-
-:math:`\textcolor{blue}{(s,k) ∈ SKA}`	                               Storage-to-disposal pipeline arcs
-
-:math:`\textcolor{blue}{(s,r) ∈ SRA}`	                               Storage-to-treatment pipeline arcs
-
-:math:`\textcolor{blue}{(s,o) ∈ SOA}`	                               Storage-to-beneficial reuse pipeline arcs
+:math:`\textcolor{blue}{i \in I}`				                           Injection (i.e. disposal) capacities
 
 
-:math:`\textcolor{blue}{(p,p) ∈ PCT}`	                               Production-to-completions trucking arcs
+:math:`\textcolor{blue}{(p,p) \in PCA}`	                               Production-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(f,c) ∈ FCT}`                                 Freshwater-to-completions trucking arcs
+:math:`\textcolor{blue}{(p,n) \in PNA}`                                 Production-to-node pipeline arcs
 
-:math:`\textcolor{blue}{(p,k) ∈ PKT}`	                               Production-to-disposal trucking arcs
+:math:`\textcolor{blue}{(p,p) \in PPA}`                                 Production-to-production pipeline arcs
 
-:math:`\textcolor{blue}{(p,s) ∈ PST}`                                 Production-to-storage trucking arcs
+:math:`\textcolor{blue}{(p,n) \in CNA}`	                               Completions-to-node pipeline arcs
 
-:math:`\textcolor{blue}{(p,r) ∈ PRT}`	                               Production-to-treatment trucking arcs
+:math:`\textcolor{blue}{(p,p) \in CCA}`	                               Completions-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(p,o) ∈ POT}`	                               Production-to-beneficial reuse trucking arcs
+:math:`\textcolor{blue}{(n,n) \in NNA}`                                 Node-to-node pipeline arcs
 
-:math:`\textcolor{blue}{(p,k) ∈ CKT}`	                               Completions-to-disposal trucking arcs
+:math:`\textcolor{blue}{(n,p) \in NCA}`                                 Node-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(p,s) ∈ CST}`	                               Completions-to-storage trucking arcs
+:math:`\textcolor{blue}{(n,k) \in NKA}`	                               Node-to-disposal pipeline arcs
 
-:math:`\textcolor{blue}{(p,r) ∈ CRT}`                                 Completions-to-treatment trucking arcs
+:math:`\textcolor{blue}{(n,s) \in NSA}`	                               Node-to-storage pipeline arcs
 
-:math:`\textcolor{blue}{(p,p) ∈ CCT}`	                               Completions-to-completions trucking arcs (flowback reuse)
+:math:`\textcolor{blue}{(n,r) \in NRA}`                                 Node-to-treatment pipeline arcs
 
-:math:`\textcolor{blue}{(s,p) ∈ SCT}`                                 Storage-to-completions trucking arcs
+:math:`\textcolor{blue}{(n,o) \in NOA}`	                               Node-to-beneficial reuse pipeline arcs
 
-:math:`\textcolor{blue}{(s,k) ∈ SKT}`                                 Storage-to-disposal trucking arcs
+:math:`\textcolor{blue}{(f,p) \in FCA}`	                               Freshwater-to-completions pipeline arcs
 
-:math:`\textcolor{blue}{(r,k) ∈ RKT}`	                               Treatment-to-disposal trucking arcs
+:math:`\textcolor{blue}{(r,n) \in RNA}`	                               Treatment-to-node pipeline arcs
+
+:math:`\textcolor{blue}{(r,p) \in RCA}`	                               Treatment-to-completions pipeline arcs
+
+:math:`\textcolor{blue}{(r,k) \in RKA}`	                               Treatment-to-disposal pipeline arcs
+
+:math:`\textcolor{blue}{(r,s) \in RSA}`			                       Treatment-to-storage pipeline arcs
+
+:math:`\textcolor{blue}{(s,n) \in SNA}`	                               Storage-to-node pipeline arcs
+
+:math:`\textcolor{blue}{(s,p) \in SCA}`	                               Storage-to-completions pipeline arcs
+
+:math:`\textcolor{blue}{(s,k) \in SKA}`	                               Storage-to-disposal pipeline arcs
+
+:math:`\textcolor{blue}{(s,r) \in SRA}`	                               Storage-to-treatment pipeline arcs
+
+:math:`\textcolor{blue}{(s,o) \in SOA}`	                               Storage-to-beneficial reuse pipeline arcs
+
+
+:math:`\textcolor{blue}{(p,p) \in PCT}`	                               Production-to-completions trucking arcs
+
+:math:`\textcolor{blue}{(f,c) \in FCT}`                                 Freshwater-to-completions trucking arcs
+
+:math:`\textcolor{blue}{(p,k) \in PKT}`	                               Production-to-disposal trucking arcs
+
+:math:`\textcolor{blue}{(p,s) \in PST}`                                 Production-to-storage trucking arcs
+
+:math:`\textcolor{blue}{(p,r) \in PRT}`	                               Production-to-treatment trucking arcs
+
+:math:`\textcolor{blue}{(p,o) \in POT}`	                               Production-to-beneficial reuse trucking arcs
+
+:math:`\textcolor{blue}{(p,k) \in CKT}`	                               Completions-to-disposal trucking arcs
+
+:math:`\textcolor{blue}{(p,s) \in CST}`	                               Completions-to-storage trucking arcs
+
+:math:`\textcolor{blue}{(p,r) \in CRT}`                                 Completions-to-treatment trucking arcs
+
+:math:`\textcolor{blue}{(p,p) \in CCT}`	                               Completions-to-completions trucking arcs (flowback reuse)
+
+:math:`\textcolor{blue}{(s,p) \in SCT}`                                 Storage-to-completions trucking arcs
+
+:math:`\textcolor{blue}{(s,k) \in SKT}`                                 Storage-to-disposal trucking arcs
+
+:math:`\textcolor{blue}{(r,k) \in RKT}`	                               Treatment-to-disposal trucking arcs
 
 
 
@@ -273,109 +273,109 @@ Strategic Model Mathematical Notation
 
 
 
-:math:`\textcolor{green}{β_{p,t}^{Production}}` = 	                   Produced water supply forecast for a production pad
+:math:`\textcolor{green}{\beta_{p,t}^{Production}}` = 	                   Produced water supply forecast for a production pad
 
-:math:`\textcolor{green}{β_{p,t}^{Flowback}}` =	                       Flowback supply forecast for a completions pad
+:math:`\textcolor{green}{\beta_{p,t}^{Flowback}}` =	                       Flowback supply forecast for a completions pad
 
-:math:`\textcolor{green}{β^{TotalProd}}` =                             Total water production (production & flowback) over the planning horizon
-
-
-
-:math:`\textcolor{green}{σ_{l,l}^{Pipeline}}` =	                       Initial weekly pipeline capacity between two locations
-
-:math:`\textcolor{green}{σ_{k}^{Disposal}}` =	                       Initial weekly disposal capacity at a disposal site
-
-:math:`\textcolor{green}{σ_{s}^{Storage}}` =                           Initial storage capacity at a storage site
-
-:math:`\textcolor{green}{σ_{p,t}^{PadStorage}}` =                      Storage capacity at completions site
-
-:math:`\textcolor{green}{σ_{r}^{Treatment}}` =                         Initial weekly treatment capacity at a treatment site
-
-:math:`\textcolor{green}{σ_{o}^{BeneficialReuse}}` =                   Initial weekly reuse capacity at a reuse site
-
-:math:`\textcolor{green}{σ_{f,t}^{Freshwater}}` =                      Weekly freshwater sourcing capacity at freshwater source
-
-:math:`\textcolor{green}{σ_{p}^{Offloading,Pad}}` =                    Weekly truck offloading sourcing capacity per pad
-
-:math:`\textcolor{green}{σ_{s}^{Offloading,Storage}}` =	               Weekly truck offloading sourcing capacity per storage site
+:math:`\textcolor{green}{\beta^{TotalProd}}` =                             Total water production (production & flowback) over the planning horizon
 
 
-:math:`\textcolor{green}{σ_{p}^{Processing,Pad}}` =                    Weekly processing (e.g. clarification) capacity per pad
 
-:math:`\textcolor{green}{σ_{s}^{Processing,Storage}}` =                Weekly processing (e.g. clarification) capacity at storage site
+:math:`\textcolor{green}{\sigma_{l,l}^{Pipeline}}` =	                       Initial weekly pipeline capacity between two locations
 
-:math:`\textcolor{green}{σ_{n}^{Node}}` =                              Weekly capacity per network node
+:math:`\textcolor{green}{\sigma_{k}^{Disposal}}` =	                       Initial weekly disposal capacity at a disposal site
+
+:math:`\textcolor{green}{\sigma_{s}^{Storage}}` =                           Initial storage capacity at a storage site
+
+:math:`\textcolor{green}{\sigma_{p,t}^{PadStorage}}` =                      Storage capacity at completions site
+
+:math:`\textcolor{green}{\sigma_{r}^{Treatment}}` =                         Initial weekly treatment capacity at a treatment site
+
+:math:`\textcolor{green}{\sigma_{o}^{BeneficialReuse}}` =                   Initial weekly reuse capacity at a reuse site
+
+:math:`\textcolor{green}{\sigma_{f,t}^{Freshwater}}` =                      Weekly freshwater sourcing capacity at freshwater source
+
+:math:`\textcolor{green}{\sigma_{p}^{Offloading,Pad}}` =                    Weekly truck offloading sourcing capacity per pad
+
+:math:`\textcolor{green}{\sigma_{s}^{Offloading,Storage}}` =	               Weekly truck offloading sourcing capacity per storage site
+
+
+:math:`\textcolor{green}{\sigma_{p}^{Processing,Pad}}` =                    Weekly processing (e.g. clarification) capacity per pad
+
+:math:`\textcolor{green}{\sigma_{s}^{Processing,Storage}}` =                Weekly processing (e.g. clarification) capacity at storage site
+
+:math:`\textcolor{green}{\sigma_{n}^{Node}}` =                              Weekly capacity per network node
 
 
 
 :math:`\textcolor{green}{W_{r}^{TreatmentComponent}}` =                Water quality component treated for at treatment site
 
-:math:`\textcolor{green}{ϵ_{r, w}^{Treatment}}` =                      Treatment efficiency at treatment site
+:math:`\textcolor{green}{\varepsilon_{r, w}^{Treatment}}` =                      Treatment efficiency at treatment site
 
-:math:`\textcolor{green}{α^{AnnualizationRate}}` =                     Annualization Rate [%]
-
-
-
-:math:`\textcolor{green}{δ_{i}^{Disposal}}` =                          Disposal capacity installation or expansion increments
-
-:math:`\textcolor{green}{δ_{c}^{Storage}}` =                           Storage capacity installation or expansion increments
-
-:math:`\textcolor{green}{δ_{j}^{Treatment}}` =                         Treatment capacity installation or expansion increments
-
-:math:`\textcolor{green}{δ^{Truck}}` =                                 Truck capacity
+:math:`\textcolor{green}{\alpha^{AnnualizationRate}}` =                     Annualization Rate [%]
 
 
 
-:math:`\textcolor{green}{τ_{k}^{Disposal}}` =                          Disposal construction or expansion lead time
+:math:`\textcolor{green}{\delta_{i}^{Disposal}}` =                          Disposal capacity installation or expansion increments
 
-:math:`\textcolor{green}{τ_{s}^{Storage}}` =                           Storage construction or expansion lead time
+:math:`\textcolor{green}{\delta_{c}^{Storage}}` =                           Storage capacity installation or expansion increments
 
-:math:`\textcolor{green}{τ_{l,l}^{Pipeline}}` =                        Pipeline construction or expansion lead time
+:math:`\textcolor{green}{\delta_{j}^{Treatment}}` =                         Treatment capacity installation or expansion increments
 
-:math:`\textcolor{green}{τ_{p,p}^{Trucking}}` =                        Drive time between two pads
+:math:`\textcolor{green}{\delta^{Truck}}` =                                 Truck capacity
 
-:math:`\textcolor{green}{τ_{p,k}^{Trucking}}` =	                       Drive time from a pad to a disposal site
 
-:math:`\textcolor{green}{τ_{p,s}^{Trucking}}` =	                       Drive time from a pad to a storage site
 
-:math:`\textcolor{green}{τ_{p,r}^{Trucking}}` =	                       Drive time from a pad to a treatment site
+:math:`\textcolor{green}{\tau_{k}^{Disposal}}` =                          Disposal construction or expansion lead time
 
-:math:`\textcolor{green}{τ_{p,o}^{Trucking}}` =                        Drive time from a pad to a beneficial reuse site
+:math:`\textcolor{green}{\tau_{s}^{Storage}}` =                           Storage construction or expansion lead time
 
-:math:`\textcolor{green}{τ_{s,p}^{Trucking}}` =	                       Drive time from a storage site to a completions site
+:math:`\textcolor{green}{\tau_{l,l}^{Pipeline}}` =                        Pipeline construction or expansion lead time
 
-:math:`\textcolor{green}{τ_{s,k}^{Trucking}}` =                        Drive time from a storage site to a disposal site
+:math:`\textcolor{green}{\tau_{p,p}^{Trucking}}` =                        Drive time between two pads
 
-:math:`\textcolor{green}{τ_{r,k}^{Trucking}}` =                        Drive time from a treatment site to a disposal site
+:math:`\textcolor{green}{\tau_{p,k}^{Trucking}}` =	                       Drive time from a pad to a disposal site
 
-:math:`\textcolor{green}{λ_{s}^{Storage}}` =                           Initial storage level at storage site
+:math:`\textcolor{green}{\tau_{p,s}^{Trucking}}` =	                       Drive time from a pad to a storage site
 
-:math:`\textcolor{green}{λ_{p}^{PadStorage}}` =                        Initial storage level at completions site
+:math:`\textcolor{green}{\tau_{p,r}^{Trucking}}` =	                       Drive time from a pad to a treatment site
 
-:math:`\textcolor{green}{θ_{s}^{Storage}}` =                           Terminal storage level at storage site
+:math:`\textcolor{green}{\tau_{p,o}^{Trucking}}` =                        Drive time from a pad to a beneficial reuse site
 
-:math:`\textcolor{green}{θ_{p}^{PadStorage}}` =                        Terminal storage level at completions site
+:math:`\textcolor{green}{\tau_{s,p}^{Trucking}}` =	                       Drive time from a storage site to a completions site
 
-:math:`\textcolor{green}{κ_{k,i}^{Disposal}}` =                        Disposal construction or expansion capital cost for selected capacity increment
+:math:`\textcolor{green}{\tau_{s,k}^{Trucking}}` =                        Drive time from a storage site to a disposal site
 
-:math:`\textcolor{green}{κ_{s,c}^{Storage}}` =                         Storage construction or expansion capital cost for selected capacity increment
+:math:`\textcolor{green}{\tau_{r,k}^{Trucking}}` =                        Drive time from a treatment site to a disposal site
 
-:math:`\textcolor{green}{κ_{r,j}^{Treatment}}` =                       Treatment construction or expansion capital cost for selected capacity increment
+:math:`\textcolor{green}{\lambda_{s}^{Storage}}` =                           Initial storage level at storage site
+
+:math:`\textcolor{green}{\lambda_{p}^{PadStorage}}` =                        Initial storage level at completions site
+
+:math:`\textcolor{green}{\theta_{s}^{Storage}}` =                           Terminal storage level at storage site
+
+:math:`\textcolor{green}{\theta_{p}^{PadStorage}}` =                        Terminal storage level at completions site
+
+:math:`\textcolor{green}{\kappa_{k,i}^{Disposal}}` =                        Disposal construction or expansion capital cost for selected capacity increment
+
+:math:`\textcolor{green}{\kappa_{s,c}^{Storage}}` =                         Storage construction or expansion capital cost for selected capacity increment
+
+:math:`\textcolor{green}{\kappa_{r,j}^{Treatment}}` =                       Treatment construction or expansion capital cost for selected capacity increment
 
 
 **The cost parameter for expanding or constructing new pipeline capacity is structured differently depending on model configuration settings. If the pipeline cost configuration is distance based:**
 
-    :math:`\textcolor{green}{κ^{Pipeline}}` =                              Pipeline construction or expansion capital cost [$/inch-mile]
+    :math:`\textcolor{green}{\kappa^{Pipeline}}` =                              Pipeline construction or expansion capital cost [$/inch-mile]
 
-    :math:`\textcolor{green}{μ_{d}^{Pipeline}}` =                          Pipeline diameter installation or expansion increments  [inch]
+    :math:`\textcolor{green}{\mu_{d}^{Pipeline}}` =                          Pipeline diameter installation or expansion increments  [inch]
 
-    :math:`\textcolor{green}{λ_{l,l}^{Pipeline}}` = 	                   Pipeline segment length [miles]
+    :math:`\textcolor{green}{\lambda_{l,l}^{Pipeline}}` = 	                   Pipeline segment length [miles]
 
 **Otherwise, if the pipeline cost configuration is capacity based:**
 
-    :math:`\textcolor{green}{κ_{l,l,d}^{Pipeline}}` =                      Pipeline construction or expansion capital cost for selected diameter capacity [$/bbl/day]
+    :math:`\textcolor{green}{\kappa_{l,l,d}^{Pipeline}}` =                      Pipeline construction or expansion capital cost for selected diameter capacity [$/bbl/day]
 
-    :math:`\textcolor{green}{δ_{d}^{Pipeline}}` =                          Pipeline capacity installation or expansion capacity increments  [bbl/day]
+    :math:`\textcolor{green}{\delta_{d}^{Pipeline}}` =                          Pipeline capacity installation or expansion capacity increments  [bbl/day]
 
 
 :math:`\textcolor{green}{π_{k}^{Disposal}}` =                          Disposal operational cost
@@ -386,7 +386,7 @@ Strategic Model Mathematical Notation
 
 :math:`\textcolor{green}{π_{s}^{Storage}}` =                           Storage deposit operational cost
 
-:math:`\textcolor{green}{ρ_{s}^{Storage}}` =                           Storage withdrawal operational credit
+:math:`\textcolor{green}{\rho_{s}^{Storage}}` =                           Storage withdrawal operational credit
 
 :math:`\textcolor{green}{π_{l,l}^{Pipeline}}` =	                       Pipeline operational cost
 
@@ -399,21 +399,21 @@ Strategic Model Mathematical Notation
 
 
 
-:math:`\textcolor{green}{ψ^{FracDemand}}` =                            Slack cost parameter
+:math:`\textcolor{green}{\psi^{FracDemand}}` =                            Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{Production}}` =                            Slack cost parameter
+:math:`\textcolor{green}{\psi^{Production}}` =                            Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{Flowback}}` =                              Slack cost parameter
+:math:`\textcolor{green}{\psi^{Flowback}}` =                              Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{PipelineCapacity}}` =                      Slack cost parameter
+:math:`\textcolor{green}{\psi^{PipelineCapacity}}` =                      Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{StorageCapacity}}` =  	                   Slack cost parameter
+:math:`\textcolor{green}{\psi^{StorageCapacity}}` =  	                   Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{DisposalCapacity}}` =                      Slack cost parameter
+:math:`\textcolor{green}{\psi^{DisposalCapacity}}` =                      Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{TreamentCapacity}}` =                      Slack cost parameter
+:math:`\textcolor{green}{\psi^{TreamentCapacity}}` =                      Slack cost parameter
 
-:math:`\textcolor{green}{ψ^{BeneficialReuseCapacity}}` =  	           Slack cost parameter
+:math:`\textcolor{green}{\psi^{BeneficialReuseCapacity}}` =  	           Slack cost parameter
 
 
 
@@ -433,7 +433,7 @@ Two objective functions can be considered for the optimization of a produced wat
 
         +\textcolor{red}{C^{TotalCompletionsReuse}}+\textcolor{red}{C^{TotalPiping}}+\textcolor{red}{C^{TotalStorage}}
 
-        + \textcolor{red}{C^{TotalTrucking}}+\textcolor{green}{α^{AnnualizationRate}}⋅(\textcolor{red}{C^{DisposalCapEx}}
+        + \textcolor{red}{C^{TotalTrucking}}+\textcolor{green}{\alpha^{AnnualizationRate}} \cdot (\textcolor{red}{C^{DisposalCapEx}}
 
         +\textcolor{red}{C^{StorageCapEx}}+\textcolor{red}{C^{TreatmentCapEx}}+\textcolor{red}{C^{PipelineCapEx}})
 
@@ -442,7 +442,7 @@ Two objective functions can be considered for the optimization of a produced wat
 
 .. math::
 
-    max = \textcolor{red}{F^{TotalCompletionsReuse}}/\textcolor{green}{β^{TotalProd}}
+    max = \textcolor{red}{F^{TotalCompletionsReuse}}/\textcolor{green}{\beta^{TotalProd}}
 
 
 
@@ -452,76 +452,76 @@ The annualization rate is calculated using the formula described at this website
 The annualization rate takes the discount rate (rate) and the number of years the CAPEX investment is expected to be used (life) as input.
 
 .. math::
-    \textcolor{green}{α^{AnnualizationRate}} = \frac{\textcolor{green}{rate}}{(1-{(1+\textcolor{green}{rate})}^{-\textcolor{green}{life}})}
+    \textcolor{green}{\alpha^{AnnualizationRate}} = \frac{\textcolor{green}{rate}}{(1-{(1+\textcolor{green}{rate})}^{-\textcolor{green}{life}})}
 
 
-**Completions Pad Demand Balance:** ∀p ∈ CP, t ∈ T
+**Completions Pad Demand Balance:** :math:`\forall p \in CP, t \in T`
 
 Completions pad demand can be met by trucked or piped water moved into the pad in addition to water in completions pad storage. For each completions pad and for each time period, completions demand at the given pad is equal to the sum of all piped and trucked water moved into the completions pad plus water removed from the pad storage minus water put into the pad storage plus a slack.
 
 .. math::
 
-    \textcolor{green}{γ_{p,t}^{Completions}} = ∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{green}{\gamma_{p,t}^{Completions}} = \sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(f,p)∈FCA}\textcolor{red}{F_{l,l,t}^{Sourced}}
+        +\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(f,p)\in FCA}\textcolor{red}{F_{l,l,t}^{Sourced}}
 
-        +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(f,p)∈FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{F_{p,t}^{PadStorageOut}}-\textcolor{red}{F_{p,t}^{PadStorageIn}}+\textcolor{red}{S_{p,t}^{FracDemand}}
+        +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{F_{p,t}^{PadStorageOut}}-\textcolor{red}{F_{p,t}^{PadStorageIn}}+\textcolor{red}{S_{p,t}^{FracDemand}}
 
 
-**Completions Pad Storage Balance:** ∀p ∈ CP, t ∈ T
+**Completions Pad Storage Balance:** :math:`\forall p \in CP, t \in T`
 
 Sets the storage level at the completions pad. For each completions pad and for each time period, completions pad storage is equal to storage in last time period plus water put in minus water removed. If it is the first time period, the pad storage is the initial pad storage.
 
 
 .. math::
 
-    \textcolor{red}{L_{p,t}^{PadStorage}} = \textcolor{green}{λ_{p,t=1}^{PadStorage}}+\textcolor{red}{L_{p,t-1}^{PadStorage}}+\textcolor{red}{F_{p,t}^{StorageIn}}-\textcolor{red}{F_{p,t}^{StorageOut}}
+    \textcolor{red}{L_{p,t}^{PadStorage}} = \textcolor{green}{\lambda_{p,t=1}^{PadStorage}}+\textcolor{red}{L_{p,t-1}^{PadStorage}}+\textcolor{red}{F_{p,t}^{StorageIn}}-\textcolor{red}{F_{p,t}^{StorageOut}}
 
 
 
-**Completions Pad Storage Capacity:** ∀p ∈ CP, t ∈ T
+**Completions Pad Storage Capacity:** :math:`\forall p \in CP, t \in T`
 
 The storage at each completions pad must always be at or below its capacity in every time period.
 
 .. math::
 
-    \textcolor{red}{L_{p,t}^{PadStorage}}≤\textcolor{green}{σ_{p}^{PadStorage}}
+    \textcolor{red}{L_{p,t}^{PadStorage}}≤\textcolor{green}{\sigma_{p}^{PadStorage}}
 
 
 
-**Terminal Completions Pad Storage Level:** ∀p ∈ CP, t ∈ T
+**Terminal Completions Pad Storage Level:** :math:`\forall p \in CP, t \in T`
 
 The storage in the last period must be at or below its terminal storage level.
 
 .. math::
 
-    \textcolor{red}{L_{p,t=T}^{PadStorage}}≤\textcolor{green}{θ_{p}^{PadStorage}}
+    \textcolor{red}{L_{p,t=T}^{PadStorage}}≤\textcolor{green}{\theta_{p}^{PadStorage}}
 
 The storage in the last period must be at or below its terminal storage level.
 
 
 
-**Freshwater Sourcing Capacity:** ∀f ∈ F, t ∈ T
+**Freshwater Sourcing Capacity:** :math:`\forall f \in F, t \in T`
 
 For each freshwater source and each time period, the outgoing water from the freshwater source is below the freshwater capacity.
 
 .. math::
 
-      ∑_{(f,p)∈FCA}\textcolor{red}{F_{l,l,t}^{Sourced}} +∑_{(f,p)∈FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{f,t}^{Freshwater}}
+      \sum\nolimits_{-}{(f,p)\in FCA}\textcolor{red}{F_{l,l,t}^{Sourced}} +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{f,t}^{Freshwater}}
 
 
 
-**Completions Pad Truck Offloading Capacity:** ∀p ∈ CP, t ∈ T
+**Completions Pad Truck Offloading Capacity:** :math:`\forall p \in CP, t \in T`
 
 For each completions pad and time period, the volume of water being trucked into the completions pad must be below the trucking offloading capacity.
 
 .. math::
 
-    ∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(f,p)∈FCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{p}^{Offloading,Pad}}
+        +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{p}^{Offloading,Pad}}
 
 
 
@@ -531,161 +531,161 @@ For each completions pad and time period, the volume of water (excluding freshwa
 
 .. math::
 
-    ∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{p}^{Processing,Pad}}
+        +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{p}^{Processing,Pad}}
 
 
 .. note:: This constraint has not actually been implemented yet.
 
 
 
-**Storage Site Truck Offloading Capacity:** ∀s ∈ S, t ∈ T
+**Storage Site Truck Offloading Capacity:** :math:`\forall s \in S, t \in T`
 
 For each storage site and each time period, the volume of water being trucked into the storage site must be below the trucking offloading capacity for that storage site.
 
 .. math::
 
-    ∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{s}^{Offloading,Storage}}
+    \sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{s}^{Offloading,Storage}}
 
 
 
-**Storage Site Processing Capacity:** ∀s ∈ S, t ∈ T
+**Storage Site Processing Capacity:** :math:`\forall s \in S, t \in T`
 
 For each storage site and each time period, the volume of water being trucked into the storage site must be less than the processing capacity for that storage site.
 
 .. math::
 
-    ∑_{(n,s)∈NSA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(r,s)∈RSA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(n,s)\in NSA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(r,s)\in RSA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{σ_{s}^{Processing,Storage}}
-
-
+        +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{green}{\sigma_{s}^{Processing,Storage}}
 
 
-**Production Pad Supply Balance:** ∀p ∈ PP, t ∈ T
+
+
+**Production Pad Supply Balance:** :math:`\forall p \in PP, t \in T`
 
 All produced water must be accounted for. For each production pad and for each time period, the volume of outgoing water must be equal to the forecasted produced water for the production pad.
 
 .. math::
 
-    \textcolor{green}{β_{p,t}^{Production}} = ∑_{(p,n)∈PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈PPA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{green}{\beta_{p,t}^{Production}} = \sum\nolimits_{-}{(p,n)\in PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in PPA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,k)∈PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,k)\in PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,r)∈PRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,o)∈POT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\textcolor{red}{S_{p,t}^{Production}}
+        +\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,o)\in POT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\textcolor{red}{S_{p,t}^{Production}}
 
 
 
-**Completions Pad Supply Balance (i.e. Flowback Balance):** ∀p ∈ CP, t ∈ T
+**Completions Pad Supply Balance (i.e. Flowback Balance):** :math:`\forall p \in CP, t \in T`
 
 All flowback water must be accounted for.  For each completions pad and for each time period, the volume of outgoing water must be equal to the forecasted flowback produced water for the completions pad.
 
 .. math::
 
-    \textcolor{green}{β_{p,t}^{Flowback}} = ∑_{(p,n)∈CNA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \textcolor{green}{\beta_{p,t}^{Flowback}} = \sum\nolimits_{-}{(p,n)\in CNA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-    +∑_{(p,k)∈CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(p,r)∈CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{S_{p,t}^{Flowback}}
+    +\sum\nolimits_{-}{(p,k)\in CKT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{S_{p,t}^{Flowback}}
 
 
 
-**Network Node Balance:** ∀n ∈ N, t ∈ T
+**Network Node Balance:** :math:`\forall n \in N, t \in T`
 
 Flow balance constraint (i.e., inputs are equal to outputs). For each pipeline node and for each time period, the volume water into the node is equal to the volume of water out of the node.
 
 .. math::
 
-    ∑_{(p,n)∈PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,n)∈CNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n ̃,n)∈NNA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,n)∈SNA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \sum\nolimits_{-}{(p,n)\in PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,n)\in CNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n TILDETILDETILDE,n)\in NNA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        = ∑_{(n,n ̃ )∈NNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(n,k)∈NKA}\textcolor{red}{F_{l,l,t}^{Piped}}
+        = \sum\nolimits_{-}{(n,n TILDETILDETILDE )\in NNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(n,k)\in NKA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(n,r)∈NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n,s)∈NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(n,o)∈NOA}\textcolor{red}{F_{l,l,t}^{Piped}}
+        +\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,o)\in NOA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
 
 
-**Bi-Directional Flow:** ∀(l,l) ∈ {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, t ∈ T
+**Bi-Directional Flow:** :math:`\forall (l,l) \in {PCA,PNA,PPA,CNA,NNA,NCA,NKA,NSA,NRA,…,SOA}, t \in T`
 
 There can only be flow in one direction for a given pipeline arc in a given time period. Flow is only allowed in a given direction if the binary indicator for that direction is “on”.
 
 
 .. math::
 
-    \textcolor{red}{y_{l,l ̃,t}^{Flow}}+\textcolor{red}{y_{l ̃,l,t}^{Flow}} = 1
+    \textcolor{red}{y_{l,\tilde{l},t}^{Flow}}+\textcolor{red}{y_{\tilde{l},l,t}^{Flow}} = 1
 
 .. note:: Technically this constraint should only be enforced for truly reversible arcs (e.g. NCA and CNA); and even then it only needs to be defined per one reversible arc (e.g. NCA only and not NCA and CNA).
 
 .. math::
 
-    \textcolor{red}{F_{l,l,t}^{Piped}}≤\textcolor{red}{y_{l,l,t}^{Flow}}⋅\textcolor{green}{M^{Flow}}
+    \textcolor{red}{F_{l,l,t}^{Piped}}≤\textcolor{red}{y_{l,l,t}^{Flow}} \cdot \textcolor{green}{M^{Flow}}
 
 
 
-**Storage Site Balance:** ∀s ∈ S, t ∈ T
+**Storage Site Balance:** :math:`\forall s \in S, t \in T`
 
 For each storage site and for each time period, if it is the first time period, the storage level is the initial storage. Otherwise, the storage level is equal to the storage level in the previous time period plus water inputs minus water outputs.
 
 .. math::
 
-    \textcolor{red}{L_{s,t}^{Storage}} = \textcolor{green}{λ_{s,t=1}^{Storage}}+\textcolor{red}{L_{s,t-1}^{Storage}}+∑_{(n,s)∈NSA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(r,s)∈RSA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,s)∈PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \textcolor{red}{L_{s,t}^{Storage}} = \textcolor{green}{\lambda_{s,t=1}^{Storage}}+\textcolor{red}{L_{s,t-1}^{Storage}}+\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(r,s)\in RSA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,s)\in PST}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,s)∈CST}\textcolor{red}{F_{l,l,t}^{Trucked}}-∑_{(s,n)∈SNA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,k)∈SKA}\textcolor{red}{F_{l,l,t}^{Piped}}
+        +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{red}{F_{l,l,t}^{Trucked}}-\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        -∑_{(s,r)∈SRA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,o)∈SOA}\textcolor{red}{F_{l,l,t}^{Piped}}-∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}}-∑_{(s,k)∈SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        -\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{red}{F_{l,l,t}^{Piped}}-\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}}-\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
 
 
-**Terminal Storage Level:** ∀s ∈ S, t ∈ T
+**Terminal Storage Level:** :math:`\forall s \in S, t \in T`
 
 For each storage site, the storage in the last time period must be less than or equal to the predicted/set terminal storage level.
 
 .. math::
 
-    \textcolor{red}{L_{s,t=T}^{Storage}}≤\textcolor{green}{θ_{s}^{Storage}}
+    \textcolor{red}{L_{s,t=T}^{Storage}}≤\textcolor{green}{\theta_{s}^{Storage}}
 
 
 
-**Network Node Capacity:** ∀n ∈ N, t ∈ T
+**Network Node Capacity:** :math:`\forall n \in N, t \in T`
 
 Flow capacity constraint. For each pipeline node and for each time period, the volume should not exceed the node capacity.
 
 .. math::
 
-    ∑_{(p,n)∈PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,n)∈CNA}\textcolor{red}{F_{l,l,t}^{Piped}} 
+    \sum\nolimits_{-}{(p,n)\in PNA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,n)\in CNA}\textcolor{red}{F_{l,l,t}^{Piped}} 
     
-    +∑_{(n ̃,n)∈NNA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,n)∈SNA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    +\sum\nolimits_{-}{(n TILDETILDETILDE,n)\in NNA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        ≤ \textcolor{green}{σ_{n}^{Node}}
+        ≤ \textcolor{green}{\sigma_{n}^{Node}}
 
 
 
-**Pipeline Capacity Construction Expansion:** ∀{l,l} ∈ {PCA,PNA,PPA,NKA,CNA,NCA,NSA,NOA,FCA,RCA,SKA,SOA,RSA,SRA}, [t ∈ T]
+**Pipeline Capacity Construction Expansion:** :math:`\forall {l,l} \in {PCA,PNA,PPA,NKA,CNA,NCA,NSA,NOA,FCA,RCA,SKA,SOA,RSA,SRA}, [t \in T]`
 
 Sets the flow capacity in a given pipeline during a given time period. Different constraints apply depending on if the pipeline is realistically reversible or not.
 
 .. math::
 
-    \textcolor{red}{F_{l,l ̂,[t]}^{Capacity}} = \textcolor{green}{σ_{l,l ̂}^{Pipeline}}+∑_{d∈D}\textcolor{green}{δ_{d}^{Pipeline}}⋅\textcolor{red}{y_{l,l ̂,d}^{Pipeline}}+\textcolor{red}{S_{l,l ̂}^{PipelineCapacity}}
+    \textcolor{red}{F_{l,\hat{l},[t]}^{Capacity}} = \textcolor{green}{\sigma_{l,\hat{l}}^{Pipeline}}+\sum\nolimits_{-}{d\in D}\textcolor{green}{\delta_{d}^{Pipeline}} \cdot \textcolor{red}{y_{l,\hat{l},d}^{Pipeline}}+\textcolor{red}{S_{l,\hat{l}}^{PipelineCapacity}}
 
-∀(l,l)∈{PPA,CNA,NNA,NCA,NSA,NRA,RNA,RKA,SNA,SCA},[t∈T]
+\forall (l,l)\in {PPA,CNA,NNA,NCA,NSA,NRA,RNA,RKA,SNA,SCA},[t\in T]
 
 .. math::
 
-    \textcolor{red}{F_{l,l ̂,[t]}^{Capacity}} = \textcolor{green}{σ_{l,l ̂}^{Pipeline}}+∑_{d∈D}\textcolor{green}{δ_{d}^{Pipeline}}⋅(\textcolor{red}{y_{l,l ̂,d}^{Pipeline}}+\textcolor{red}{y_{l ̂,l,d}^{Pipeline}} )+\textcolor{red}{S_{l,l ̂}^{PipelineCapacity}}
+    \textcolor{red}{F_{l,\hat{l},[t]}^{Capacity}} = \textcolor{green}{\sigma_{l,\hat{l}}^{Pipeline}}+\sum\nolimits_{-}{d\in D}\textcolor{green}{\delta_{d}^{Pipeline}} \cdot (\textcolor{red}{y_{l,\hat{l},d}^{Pipeline}}+\textcolor{red}{y_{\hat{l},l,d}^{Pipeline}} )+\textcolor{red}{S_{l,\hat{l}}^{PipelineCapacity}}
 
 .. note::
 
-    δ can be input by user or calculated. If the user chooses to calculate pipeline capacity, the parameter will be calculated by the equation below where :math:`{κ_{l,l}}` is Hazen-Williams constant and ω is Hazen-Williams exponent as per Cafaro & Grossmann (2021) and d represents the pipeline diameter as per the set d∈D.
+    \delta can be input by user or calculated. If the user chooses to calculate pipeline capacity, the parameter will be calculated by the equation below where :math:`{\kappa_{l,l}}` is Hazen-Williams constant and \omega is Hazen-Williams exponent as per Cafaro & Grossmann (2021) and d represents the pipeline diameter as per the set d\in D.
 
     See equation:
 
 .. math::
 
-    \textcolor{green}{δ_{d}^{Pipeline}} = {κ_{l,l}}⋅\textcolor{blue}{d}^{ω}
+    \textcolor{green}{\delta_{d}^{Pipeline}} = {\kappa_{l,l}} \cdot \textcolor{blue}{d}^{\omega}
 
 
-∀{l,l} ∈ {PCA,PNA,PPA,CNA,RCA NNA,NCA,NKA,NSA,NRA,…,SOA}, t ∈ T
+\forall {l,l} \in {PCA,PNA,PPA,CNA,RCA NNA,NCA,NKA,NSA,NRA,…,SOA}, t \in T
 
 .. math::
 
@@ -693,15 +693,15 @@ Sets the flow capacity in a given pipeline during a given time period. Different
 
 
 
-**Storage Capacity Construction/Expansion:** ∀s ∈ S, [t ∈ T]
+**Storage Capacity Construction/Expansion:** :math:`\forall s \in S, [t \in T]`
 
 This constraint accounts for the expansion of available storage capacity or installation of storage facilities. If expansion/construction is selected, expand the capacity by the set expansion amount. The water level at the storage site must be less than this capacity. As of now, the model considers that a storage facility is expanded or built at the beginning of the planning horizon. The C0 notation indicates that we also include the 0th case, meaning that there is no selection in the set C where no capacity is added.
 
 .. math::
 
-    \textcolor{red}{X_{s,[t]}^{Capacity}} = \textcolor{green}{σ_{s}^{Storage}}+∑_{c∈C_0}\textcolor{green}{δ_{c}^{Storage}}⋅\textcolor{red}{y_{s,c}^{Storage}}+\textcolor{red}{S_{s}^{StorageCapacity}}
+    \textcolor{red}{X_{s,[t]}^{Capacity}} = \textcolor{green}{\sigma_{s}^{Storage}}+\sum\nolimits_{-}{c\in C_0}\textcolor{green}{\delta_{c}^{Storage}} \cdot \textcolor{red}{y_{s,c}^{Storage}}+\textcolor{red}{S_{s}^{StorageCapacity}}
 
-∀s ∈ S, t ∈ T
+\forall s \in S, t \in T
 
 .. math::
 
@@ -709,76 +709,76 @@ This constraint accounts for the expansion of available storage capacity or inst
 
 
 
-**Disposal Capacity Construction/Expansion:** ∀k ∈ K, [t ∈ T]
+**Disposal Capacity Construction/Expansion:** :math:`\forall k \in K, [t \in T]`
 
 This constraint accounts for the expansion of available disposal sites or installation of new disposal sites. If expansion/construction is selected, expand the capacity by the set expansion amount. The total disposed water in a given time period must be less than this new capacity.
 
 .. math::
 
-    \textcolor{red}{D_{k,[t]}^{Capacity}} = \textcolor{green}{σ_{k}^{Disposal}}+∑_{i∈I_0}\textcolor{green}{δ_{i}^{Disposal}}⋅\textcolor{red}{y_{k,i}^{Disposal}}+\textcolor{red}{S_{k}^{DisposalCapacity}}
+    \textcolor{red}{D_{k,[t]}^{Capacity}} = \textcolor{green}{\sigma_{k}^{Disposal}}+\sum\nolimits_{-}{i\in I_0}\textcolor{green}{\delta_{i}^{Disposal}} \cdot \textcolor{red}{y_{k,i}^{Disposal}}+\textcolor{red}{S_{k}^{DisposalCapacity}}
 
-∀k ∈ K, t ∈ T
+\forall k \in K, t \in T
 
 .. math::
 
-    ∑_{(n,k)∈NKA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,k)∈SKA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,k)∈SKT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,k)∈PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(n,k)\in NKA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,k)\in PKT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,k)∈CKT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(r,k)∈RKT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{red}{D_{k,[t]}^{Capacity}}
+        +\sum\nolimits_{-}{(p,k)\in CKT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(r,k)\in RKT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{red}{D_{k,[t]}^{Capacity}}
 
 
 
-**Treatment Capacity Construction/Expansion:** ∀r ∈ R, [t ∈ T]
+**Treatment Capacity Construction/Expansion:** :math:`\forall r \in R, [t \in T]`
 
 Similarly to Disposal and Storage Capacity Construction/Expansion constraints, the current treatment capacity can be expanded as required or new facilities may be installed.
 
 .. math::
 
-    \textcolor{red}{T_{r,[t]}^{Capacity}} = \textcolor{green}{σ_{r}^{Treatment}}+∑_{j∈J_0}\textcolor{green}{δ_{j}^{Treatment}}⋅\textcolor{red}{y_{r,j}^{Treatment}}+\textcolor{red}{S_{r}^{TreatmentCapacity}}
+    \textcolor{red}{T_{r,[t]}^{Capacity}} = \textcolor{green}{\sigma_{r}^{Treatment}}+\sum\nolimits_{-}{j\in J_0}\textcolor{green}{\delta_{j}^{Treatment}} \cdot \textcolor{red}{y_{r,j}^{Treatment}}+\textcolor{red}{S_{r}^{TreatmentCapacity}}
 
-∀r ∈ R, t ∈ T
+\forall r \in R, t \in T
 
 .. math::
 
-    ∑_{(n,r)∈NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,r)∈SRA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,r)∈PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(n,r)\in NRA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,r)∈CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{red}{T_{r,[t]}^{Capacity}}
+        +\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} ≤\textcolor{red}{T_{r,[t]}^{Capacity}}
 
 
-**Treatment Balance:** ∀r ∈ R, t ∈ T
+**Treatment Balance:** :math:`\forall r \in R, t \in T`
 
 Water input into treatment facility is treated with a level of efficiency, meaning only a given percentage of the water input is outputted to be reused at the completions pads.
 
 .. math::
 
-    \textcolor{green}{ϵ_{r, \textcolor{green}{W_{r}^{TreatmentComponent}}}^{Treatment}}⋅(∑_{(n,r)∈NRA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,r)∈SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,r)∈PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \textcolor{green}{\varepsilon_{r, \textcolor{green}{W_{r}^{TreatmentComponent}}}^{Treatment}} \cdot (\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,r)∈CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} )=∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} + \textcolor{red}{F_{r,t}^{UnusedTreatedWater}}
+        +\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{red}{F_{l,l,t}^{Trucked}} )=\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} + \textcolor{red}{F_{r,t}^{UnusedTreatedWater}}
 
-where :math:`\textcolor{green}{ϵ_{r, w}^{Treatment}}` <1
+where :math:`\textcolor{green}{\varepsilon_{r, w}^{Treatment}}` \le1
 
 
 
-**Beneficial Reuse Capacity:** ∀o ∈ O, t ∈ T
+**Beneficial Reuse Capacity:** :math:`\forall o \in O, t \in T`
 
 For each beneficial reuse site and for each time period, water sent to a site must be less than or equal to the capacity.
 
 .. math::
 
-    ∑_{(n,o)∈NOA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(s,o)∈SOA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,o)∈POT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+    \sum\nolimits_{-}{(n,o)\in NOA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,o)\in POT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        ≤\textcolor{green}{σ_{o}^{BeneficialReuse}}+\textcolor{red}{S_{o}^{BeneficialReuseCapacity}}
+        ≤\textcolor{green}{\sigma_{o}^{BeneficialReuse}}+\textcolor{red}{S_{o}^{BeneficialReuseCapacity}}
 
 
 
-**Fresh Sourcing Cost:**  ∀f ∈ F, p ∈ CP, t ∈ T
+**Fresh Sourcing Cost:** :math:`\forall f \in F, p \in CP, t \in T`
 
 For each freshwater source, for each completions pad, and for each time period, the freshwater sourcing cost is equal to all output from the freshwater source times the freshwater sourcing cost.
 
 .. math::
 
-    \textcolor{red}{C_{f,p,t}^{Sourced}} =(\textcolor{red}{F_{f,p,t}^{Sourced}}+\textcolor{red}{F_{f,p,t}^{Trucked}})⋅\textcolor{green}{π_{f}^{Sourcing}}
+    \textcolor{red}{C_{f,p,t}^{Sourced}} =(\textcolor{red}{F_{f,p,t}^{Sourced}}+\textcolor{red}{F_{f,p,t}^{Trucked}}) \cdot \textcolor{green}{π_{f}^{Sourcing}}
 
-    \textcolor{red}{C^{TotalSourced}} = ∑_{∀t∈T}∑_{(f,p)∈FCA}\textcolor{red}{C_{f,p,t}^{Sourced}}
+    \textcolor{red}{C^{TotalSourced}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{(f,p)\in FCA}\textcolor{red}{C_{f,p,t}^{Sourced}}
 
 
 
@@ -788,19 +788,19 @@ The total fresh sourced volume is the sum of freshwater movements by truck and p
 
 .. math::
 
-    \textcolor{red}{F^{TotalSourced}} = ∑_{∀t∈T}∑_{f∈F}∑_{p∈CP}(\textcolor{red}{F_{f,p,t}^{Sourced}}+\textcolor{red}{F_{f,p,t}^{Trucked}})
+    \textcolor{red}{F^{TotalSourced}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{f\in F}\sum\nolimits_{-}{p\in CP}(\textcolor{red}{F_{f,p,t}^{Sourced}}+\textcolor{red}{F_{f,p,t}^{Trucked}})
 
 
 
-**Disposal Cost:** ∀k ∈ K, t ∈ T
+**Disposal Cost:** :math:`\forall k \in K, t \in T`
 
 For each disposal site, for each time period, the disposal cost is equal to all water moved into the disposal site multiplied by the operational disposal cost. Total disposal cost is the sum of disposal costs over all time periods and all disposal sites.
 
 .. math::
 
-       \textcolor{red}{C_{k,t}^{Disposal}} = (∑_{(l,k)∈{NKA,RKA,SKA}}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(l,k)∈{PKT,CKT,SKT,RKT}}\textcolor{red}{F_{l,l,t}^{Trucked}})⋅ \textcolor{green}{π_{k}^{Disposal}}
+       \textcolor{red}{C_{k,t}^{Disposal}} = (\sum\nolimits_{-}{(l,k)\in {NKA,RKA,SKA}}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(l,k)\in {PKT,CKT,SKT,RKT}}\textcolor{red}{F_{l,l,t}^{Trucked}}) \cdot \textcolor{green}{π_{k}^{Disposal}}
 
-       \textcolor{red}{C^{TotalDisposal}} = ∑_{∀t∈T}∑_{k∈K}\textcolor{red}{C_{k,t}^{Disposal}}
+       \textcolor{red}{C^{TotalDisposal}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{k\in K}\textcolor{red}{C_{k,t}^{Disposal}}
 
 
 
@@ -810,40 +810,40 @@ Total disposed volume over all time is the sum of all piped and trucked water to
 
 .. math::
 
-    \textcolor{red}{F^{TotalDisposed}} = ∑_{∀t∈T}(∑_{(l,l)∈{NKA,RKA,SKA}}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(l,l)∈{PKT,CKT,SKT,RKT}}\textcolor{red}{F_{l,l,t}^{Trucked}})
+    \textcolor{red}{F^{TotalDisposed}} = \sum\nolimits_{-}{\forall t\in T}(\sum\nolimits_{-}{(l,l)\in {NKA,RKA,SKA}}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(l,l)\in {PKT,CKT,SKT,RKT}}\textcolor{red}{F_{l,l,t}^{Trucked}})
 
 
 
-**Treatment Cost:** ∀r ∈ R, t ∈ T
+**Treatment Cost:** :math:`\forall r \in R, t \in T`
 
 For each treatment site, for each time period, the treatment cost is equal to all water moved to the treatment site multiplied by the operational treatment cost. The total treatments cost is the sum of treatment costs over all time periods and all treatment sites.
 
 .. math::
 
-    \textcolor{red}{C_{r,t}^{Treatment}} = (∑_{(l,l)∈{NRA,SRA}}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(l,l)∈{PRT,CRT}}\textcolor{red}{F_{l,l,t}^{Trucked}})⋅ \textcolor{green}{π_{r}^{Treatment}}
+    \textcolor{red}{C_{r,t}^{Treatment}} = (\sum\nolimits_{-}{(l,l)\in {NRA,SRA}}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(l,l)\in {PRT,CRT}}\textcolor{red}{F_{l,l,t}^{Trucked}}) \cdot \textcolor{green}{π_{r}^{Treatment}}
 
-    \textcolor{red}{C^{TotalTreatment}} = ∑_{∀t∈T}∑_{r∈R}\textcolor{red}{C_{r,t}^{Treatment}}
+    \textcolor{red}{C^{TotalTreatment}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{r\in R}\textcolor{red}{C_{r,t}^{Treatment}}
 
 
 
-**Completions Reuse Cost:** ∀p ∈ P, t ∈ T
+**Completions Reuse Cost:** :math:`\forall p \in P, t \in T`
 
 Completions reuse water is all water that meets completions pad demand, excluding freshwater. Completions reuse cost is the volume of completions reused water multiplied by the cost for reuse.
 
 .. math::
 
-    \textcolor{red}{C_{p,t}^{CompletionsReuse}} = (∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{red}{C_{p,t}^{CompletionsReuse}} = (\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}})⋅ \textcolor{green}{π_{p}^{CompletionsReuse}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}}) \cdot \textcolor{green}{π_{p}^{CompletionsReuse}}
 
 
 .. note:: Freshwater sourcing is excluded from completions reuse costs.
 
 .. math::
 
-    \textcolor{red}{C^{TotalReuse}} = ∑_{∀t∈T}∑_{p∈CP}\textcolor{red}{C_{p,t}^{Reuse}}
+    \textcolor{red}{C^{TotalReuse}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{p\in CP}\textcolor{red}{C_{p,t}^{Reuse}}
 
 
 
@@ -853,56 +853,56 @@ The total reuse volume is the total volume of produced water reused, or the tota
 
 .. math::
 
-    \textcolor{red}{F^{TotalCompletionsReused}} = ∑_{∀t∈T}(∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{red}{F^{TotalCompletionsReused}} = \sum\nolimits_{-}{\forall t\in T}(\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(p,p)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}})
+        +\sum\nolimits_{-}{(p,p)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}})
 
 
 
-**Piping Cost:** ∀(l,l) ∈ {PPA,…,CCA}, t ∈ T
+**Piping Cost:** :math:`\forall (l,l) \in {PPA,…,CCA}, t \in T`
 
 Piping cost is the total volume of piped water multiplied by the cost for piping.
 
 .. math::
 
-    \textcolor{red}{C_{l,l,t}^{Piped}} = (\textcolor{red}{F_{l,l,t}^{Piped}}+\textcolor{red}{F_{l,l,t}^{Sourced})}⋅ \textcolor{green}{π_{l,l}^{Pipeline}}
+    \textcolor{red}{C_{l,l,t}^{Piped}} = (\textcolor{red}{F_{l,l,t}^{Piped}}+\textcolor{red}{F_{l,l,t}^{Sourced})} \cdot \textcolor{green}{π_{l,l}^{Pipeline}}
 
-    \textcolor{red}{C^{TotalPiping}} = ∑_{t∈T}∑_{∀(l,l)∈{PPA,…}}\textcolor{red}{C_{l,l,t}^{Piped}}
+    \textcolor{red}{C^{TotalPiping}} = \sum\nolimits_{-}{t\in T}\sum\nolimits_{-}{\forall (l,l)\in {PPA,…}}\textcolor{red}{C_{l,l,t}^{Piped}}
 
 
 .. note:: The constraints above explicitly consider freshwater piping via FCA arcs.
 
 
 
-**Storage Deposit Cost:** ∀s ∈ S, t ∈ T
+**Storage Deposit Cost:** :math:`\forall s \in S, t \in T`
 
 Cost of depositing into storage is equal to the total volume of water moved into storage multiplied by the storage operation cost rate.
 
 .. math::
 
-    \textcolor{red}{C_{s,t}^{Storage}} = (∑_{(l,s)∈{NSA}}\textcolor{red}{F_{l,s,t}^{Piped}} +∑_{(l,s)∈{RSA}}\textcolor{red}{F_{l,s,t}^{Piped}}
+    \textcolor{red}{C_{s,t}^{Storage}} = (\sum\nolimits_{-}{(l,s)\in {NSA}}\textcolor{red}{F_{l,s,t}^{Piped}} +\sum\nolimits_{-}{(l,s)\in {RSA}}\textcolor{red}{F_{l,s,t}^{Piped}}
 
-        +∑_{(l,s)∈{CST}}\textcolor{red}{F_{l,s,t}^{Trucked}}+∑_{(l,s)∈{PST}}\textcolor{red}{F_{l,s,t}^{Trucked}})⋅ \textcolor{green}{π_{s}^{Storage}}
+        +\sum\nolimits_{-}{(l,s)\in {CST}}\textcolor{red}{F_{l,s,t}^{Trucked}}+\sum\nolimits_{-}{(l,s)\in {PST}}\textcolor{red}{F_{l,s,t}^{Trucked}}) \cdot \textcolor{green}{π_{s}^{Storage}}
 
-    \textcolor{red}{C^{TotalStorage}} = ∑_{∀t∈T}∑_{∀s∈S}\textcolor{red}{C_{s,t}^{Storage}}
+    \textcolor{red}{C^{TotalStorage}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall s\in S}\textcolor{red}{C_{s,t}^{Storage}}
 
 
 
-**Storage Withdrawal Credit:** ∀s ∈ S, t ∈ T
+**Storage Withdrawal Credit:** :math:`\forall s \in S, t \in T`
 
 Credits from withdrawing from storage is equal to the total volume of water moved out from storage multiplied by the storage operation credit rate.
 
 .. math::
 
-    \textcolor{red}{R_{s,t}^{Storage}} = (∑_{(s,l)∈{SNA,SCA,SKA,SRA,SOA}}\textcolor{red}{F_{s,l,t}^{Piped}}+∑_{(s,l)∈{SCT,SKT}}\textcolor{red}{F_{s,l,t}^{Trucked}})⋅ \textcolor{green}{ρ_{s}^{Storage}}
+    \textcolor{red}{R_{s,t}^{Storage}} = (\sum\nolimits_{-}{(s,l)\in {SNA,SCA,SKA,SRA,SOA}}\textcolor{red}{F_{s,l,t}^{Piped}}+\sum\nolimits_{-}{(s,l)\in {SCT,SKT}}\textcolor{red}{F_{s,l,t}^{Trucked}}) \cdot \textcolor{green}{\rho_{s}^{Storage}}
 
-    \textcolor{red}{R^{TotalStorage}} = ∑_{∀t∈T}∑_{∀s∈S}\textcolor{red}{R_{s,t}^{Storage}}
+    \textcolor{red}{R^{TotalStorage}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall s\in S}\textcolor{red}{R_{s,t}^{Storage}}
 
 
 
-**Pad Storage Cost:** ∀l ∈ L, l ̃ ∈ L, t ∈ T
+**Pad Storage Cost:** :math:`\forall l \in L, \tilde{l}\in L, t \in T`
 
 **Trucking Cost (Simplified)**
 
@@ -910,9 +910,9 @@ Trucking cost between two locations for time period is equal to the trucking vol
 
 .. math::
 
-    \textcolor{red}{C_{l,l ̃  ,t}^{Trucked}} = \textcolor{red}{F_{l,l ̃,t}^{Trucked}}⋅\textcolor{green}{1⁄δ^{Truck}} ⋅\textcolor{green}{τ_{l,l ̃}^{Trucking}}⋅\textcolor{green}{π_{l}^{Trucking}}
+    \textcolor{red}{C_{l,\tilde{l},t}^{Trucked}} = \textcolor{red}{F_{l,\tilde{l},t}^{Trucked}} \cdot \textcolor{green}{1/\delta^{Truck}} \cdot \textcolor{green}{\tau_{l,\tilde{l}}^{Trucking}} \cdot \textcolor{green}{π_{l}^{Trucking}}
 
-    \textcolor{red}{C^{TotalTrucking}} = ∑_{∀t∈T}∑_{∀(l,l)∈{PPA,…,CCT}}\textcolor{red}{C_{l,l ̃  ,t}^{Trucked}}
+    \textcolor{red}{C^{TotalTrucking}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall (l,l)\in {PPA,…,CCT}}\textcolor{red}{C_{l,\tilde{l},t}^{Trucked}}
 
 
 .. note:: The constraints above explicitly consider freshwater trucking via FCT arcs.
@@ -920,47 +920,47 @@ Trucking cost between two locations for time period is equal to the trucking vol
 
 
 
-**Total Trucking Volume:** ∀t ∈ T
+**Total Trucking Volume:** :math:`\forall t \in T`
 
 The total trucking volume is estimated as the summation of trucking movements over all time periods and locations.
 
 .. math::
 
-    \textcolor{red}{F^{TotalTrucking}} = ∑_{∀t∈T}∑_{∀(l,l)∈{PPA,…,CCT}}\textcolor{red}{F_{l,l ̃  ,t}^{Trucked}}
+    \textcolor{red}{F^{TotalTrucking}} = \sum\nolimits_{-}{\forall t\in T}\sum\nolimits_{-}{\forall (l,l)\in {PPA,…,CCT}}\textcolor{red}{F_{l,\tilde{l},t}^{Trucked}}
 
 
 
-**Disposal Construction or Capacity Expansion Cost:** ∀t ∈ T
+**Disposal Construction or Capacity Expansion Cost:** :math:`\forall t \in T`
 
 Cost related to expanding or constructing new disposal capacity. Takes into consideration capacity increment, cost for selected capacity increment, and if the construction/expansion is selected to occur.
 
 .. math::
 
-    \textcolor{red}{C_{[t]}^{DisposalCapEx}} = ∑_{i∈I_0} ∑_{k∈K}\textcolor{green}{κ_{k,i}^{Disposal}}⋅\textcolor{green}{δ_{i}^{Disposal}}⋅\textcolor{red}{y_{k,i}^{Disposal}}
+    \textcolor{red}{C_{[t]}^{DisposalCapEx}} = \sum\nolimits_{-}{i\in I_0} \sum\nolimits_{-}{k\in K}\textcolor{green}{\kappa_{k,i}^{Disposal}} \cdot \textcolor{green}{\delta_{i}^{Disposal}} \cdot \textcolor{red}{y_{k,i}^{Disposal}}
 
 
 
-**Storage Construction or Capacity Expansion Cost:** ∀t ∈ T
+**Storage Construction or Capacity Expansion Cost:** :math:`\forall t \in T`
 
 Cost related to expanding or constructing new storage capacity. Takes into consideration capacity increment, cost for selected capacity increment, and if the construction/expansion is selected to occur.
 
 .. math::
 
-    \textcolor{red}{C_{[t]}^{StorageCapEx}} = ∑_{s∈S} ∑_{c∈C_0}\textcolor{green}{κ_{s,c}^{Storage}}⋅\textcolor{green}{δ_{c}^{Storage}}⋅\textcolor{red}{y_{s,c}^{Storage}}
+    \textcolor{red}{C_{[t]}^{StorageCapEx}} = \sum\nolimits_{-}{s\in S} \sum\nolimits_{-}{c\in C_0}\textcolor{green}{\kappa_{s,c}^{Storage}} \cdot \textcolor{green}{\delta_{c}^{Storage}} \cdot \textcolor{red}{y_{s,c}^{Storage}}
 
 
 
-**Treatment Construction or Capacity Expansion Cost:** ∀t ∈ T
+**Treatment Construction or Capacity Expansion Cost:** :math:`\forall t \in T`
 
 Cost related to expanding or constructing new treatment capacity. Takes into consideration capacity increment, cost for selected capacity increment, and if the construction/expansion is selected to occur.
 
 .. math::
 
-    \textcolor{red}{C_{[t]}^{TreatmentCapEx}} = ∑_{r∈R}∑_{j∈J_0}\textcolor{green}{κ_{r,j}^{Treatment}}⋅\textcolor{green}{δ_{j}^{Treatment}}⋅\textcolor{red}{y_{r,j}^{Treatment}}
+    \textcolor{red}{C_{[t]}^{TreatmentCapEx}} = \sum\nolimits_{-}{r\in R}\sum\nolimits_{-}{j\in J_0}\textcolor{green}{\kappa_{r,j}^{Treatment}} \cdot \textcolor{green}{\delta_{j}^{Treatment}} \cdot \textcolor{red}{y_{r,j}^{Treatment}}
 
 
 
-**Pipeline Construction or Capacity Expansion Cost:** ∀t ∈ T
+**Pipeline Construction or Capacity Expansion Cost:** :math:`\forall t \in T`
 
 Cost related to expanding or constructing new pipeline capacity is calculated differently depending on model configuration settings.
 
@@ -969,13 +969,13 @@ If the pipeline cost configuration is **capacity based**, pipeline expansion cos
 
 .. math::
 
-    \textcolor{red}{C_{[t]}^{PipelineCapEx}} = ∑_{l∈L}∑_{l∈L}∑_{d∈D_0}\textcolor{green}{κ_{l,l,d}^{Pipeline}}⋅\textcolor{green}{δ_{d}^{Pipeline}}⋅\textcolor{red}{y_{l,l,d}^{Pipeline}}
+    \textcolor{red}{C_{[t]}^{PipelineCapEx}} = \sum\nolimits_{-}{l\in L}\sum\nolimits_{-}{l\in L}\sum\nolimits_{-}{d\in D_0}\textcolor{green}{\kappa_{l,l,d}^{Pipeline}} \cdot \textcolor{green}{\delta_{d}^{Pipeline}} \cdot \textcolor{red}{y_{l,l,d}^{Pipeline}}
 
 If the pipeline cost configuration is **distance based**, pipeline expansion cost is calculated using pipeline distances, pipeline diameters, cost per inch mile, and if the construction/expansion is selected to occur.
 
 .. math::
 
-    \textcolor{red}{C_{[t]}^{PipelineCapEx}} = ∑_{l∈L}∑_{l∈L}∑_{d∈D_0}\textcolor{green}{κ^{Pipeline}⋅}\textcolor{green}{μ_{d}^{Pipeline}}⋅\textcolor{green}{λ_{l,l}^{Pipeline}}⋅\textcolor{red}{y_{l,l,d}^{Pipeline}}
+    \textcolor{red}{C_{[t]}^{PipelineCapEx}} = \sum\nolimits_{-}{l\in L}\sum\nolimits_{-}{l\in L}\sum\nolimits_{-}{d\in D_0}\textcolor{green}{\kappa^{Pipeline} \cdot }\textcolor{green}{\mu_{d}^{Pipeline}} \cdot \textcolor{green}{\lambda_{l,l}^{Pipeline}} \cdot \textcolor{red}{y_{l,l,d}^{Pipeline}}
 
 
 
@@ -985,41 +985,41 @@ Weighted sum of the slack variables. In the case that the model is infeasible, t
 
 .. math::
 
-    \textcolor{red}{C^{Slack}} = ∑_{p∈CP}∑_{t∈T}\textcolor{red}{S_{p,t}^{FracDemand}}⋅\textcolor{green}{ψ^{FracDemand}}+∑_{p∈PP}∑_{t∈T}\textcolor{red}{S_{p,t}^{Production}} ⋅\textcolor{green}{ψ^{Production}}
+    \textcolor{red}{C^{Slack}} = \sum\nolimits_{-}{p\in CP}\sum\nolimits_{-}{t\in T}\textcolor{red}{S_{p,t}^{FracDemand}} \cdot \textcolor{green}{\psi^{FracDemand}}+\sum\nolimits_{-}{p\in PP}\sum\nolimits_{-}{t\in T}\textcolor{red}{S_{p,t}^{Production}} \cdot \textcolor{green}{\psi^{Production}}
 
-        +∑_{p∈CP}∑_{t∈T}\textcolor{red}{S_{p,t}^{Flowback}}⋅\textcolor{green}{ψ^{Flowback}}+∑_{(l,l)∈{…}}\textcolor{red}{S_{l,l}^{PipelineCapacity}} ⋅\textcolor{green}{ψ^{PipeCapacity}}
+        +\sum\nolimits_{-}{p\in CP}\sum\nolimits_{-}{t\in T}\textcolor{red}{S_{p,t}^{Flowback}} \cdot \textcolor{green}{\psi^{Flowback}}+\sum\nolimits_{-}{(l,l)\in {…}}\textcolor{red}{S_{l,l}^{PipelineCapacity}} \cdot \textcolor{green}{\psi^{PipeCapacity}}
 
-         +∑_{s∈S}\textcolor{red}{S_{s}^{StorageCapacity}} ⋅\textcolor{green}{ψ^{StorageCapacity}}+∑_{k∈K}\textcolor{red}{S_{k}^{DisposalCapacity}}⋅\textcolor{green}{ψ^{DisposalCapacity}}
+         +\sum\nolimits_{-}{s\in S}\textcolor{red}{S_{s}^{StorageCapacity}} \cdot \textcolor{green}{\psi^{StorageCapacity}}+\sum\nolimits_{-}{k\in K}\textcolor{red}{S_{k}^{DisposalCapacity}} \cdot \textcolor{green}{\psi^{DisposalCapacity}}
 
-         +∑_{r∈R}\textcolor{red}{S_{r}^{TreatmentCapacity}} ⋅\textcolor{green}{ψ^{TreatmentCapacity}}+∑_{o∈O}\textcolor{red}{S_{o}^{BeneficialReuseCapacity}} ⋅\textcolor{green}{ψ^{BeneficialReuseCapacity}}
+         +\sum\nolimits_{-}{r\in R}\textcolor{red}{S_{r}^{TreatmentCapacity}} \cdot \textcolor{green}{\psi^{TreatmentCapacity}}+\sum\nolimits_{-}{o\in O}\textcolor{red}{S_{o}^{BeneficialReuseCapacity}} \cdot \textcolor{green}{\psi^{BeneficialReuseCapacity}}
 
 
 
-**Logic Constraints:** ∀k ∈ K
+**Logic Constraints:** :math:`\forall k \in K`
 
 New pipeline or facility capacity constraints: e.g., only one injection capacity can be used for a given site
 
 .. math::
 
-    ∑_{i∈I_0}\textcolor{red}{y_{k,i,[t]}^{Disposal}} = 1
+    \sum\nolimits_{-}{i\in I_0}\textcolor{red}{y_{k,i,[t]}^{Disposal}} = 1
 
-∀s ∈ S
-
-.. math::
-
-    ∑_{c∈C_0}\textcolor{red}{y_{s,c,[t]}^{Storage}} = 1
-
-∀r ∈ R
+\forall s \in S
 
 .. math::
 
-    ∑_{j∈J_0}\textcolor{red}{y_{r,j,[t]}^{Treatment}} = 1
+    \sum\nolimits_{-}{c\in C_0}\textcolor{red}{y_{s,c,[t]}^{Storage}} = 1
 
-∀l ∈ L, l ∈ L
+\forall r \in R
 
 .. math::
 
-    ∑_{d∈D_0}\textcolor{red}{y_{l,l,d,[t]}^{Pipeline}} = 1
+    \sum\nolimits_{-}{j\in J_0}\textcolor{red}{y_{r,j,[t]}^{Treatment}} = 1
+
+\forall l \in L, l \in L
+
+.. math::
+
+    \sum\nolimits_{-}{d\in D_0}\textcolor{red}{y_{l,l,d,[t]}^{Pipeline}} = 1
 
 
 
@@ -1027,31 +1027,31 @@ New pipeline or facility capacity constraints: e.g., only one injection capacity
 **Deliveries Destination Constraints:**
 
 Completions reuse deliveries at a completions pad in time period t is equal to all piped and trucked water moved into the completions pad, excluding freshwater.
-∀p ∈ CP, t ∈ T
+\forall p \in CP, t \in T
 
 .. math::
 
-    \textcolor{red}{F_{p,t}^{CompletionsReuseDestination}} = ∑_{l∈{P,N,R,S}}\textcolor{red}{F_{l,p,t}^{Piped}}+\textcolor{red}{F_{l,p,t}^{Trucked}}
+    \textcolor{red}{F_{p,t}^{CompletionsReuseDestination}} = \sum\nolimits_{-}{l\in {P,N,R,S}}\textcolor{red}{F_{l,p,t}^{Piped}}+\textcolor{red}{F_{l,p,t}^{Trucked}}
 
 Disposal deliveries for disposal site k at time t is equal to all piped and trucked water moved to the disposal site k.
-∀k ∈ K, t ∈ T
+\forall k \in K, t \in T
 
 .. math::
 
-    \textcolor{red}{F_{k,t}^{DisposalDestination}} = ∑_{l∈L}\textcolor{red}{F_{l,k,t}^{Piped}}+\textcolor{red}{F_{l,k,t}^{Trucked}}
+    \textcolor{red}{F_{k,t}^{DisposalDestination}} = \sum\nolimits_{-}{l\in L}\textcolor{red}{F_{l,k,t}^{Piped}}+\textcolor{red}{F_{l,k,t}^{Trucked}}
 
 Completions deliveries destination for completions pad p at time t is equal to all piped and trucked water moved to the completions pad.
-∀p ∈ CP, t ∈ T
+\forall p \in CP, t \in T
 
 .. math::
 
-    \textcolor{red}{F_{p,t}^{CompletionsDestination}}  = ∑_{(n,p)∈NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+∑_{(s,p)∈SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
+    \textcolor{red}{F_{p,t}^{CompletionsDestination}}  = \sum\nolimits_{-}{(n,p)\in NCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{red}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{red}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,c)∈CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(r,p)∈RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +∑_{(f,p)∈FCA}\textcolor{red}{F_{l,l,t}^{Sourced}}
+        +\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{red}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(f,p)\in FCA}\textcolor{red}{F_{l,l,t}^{Sourced}}
 
-        +∑_{(p,p)∈PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(s,p)∈SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +∑_{(p,p)∈CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{red}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(f,p)∈FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{F_{p,t}^{PadStorageOut}}-\textcolor{red}{F_{p,t}^{PadStorageIn}}
+        +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{red}{F_{l,l,t}^{Trucked}} +\textcolor{red}{F_{p,t}^{PadStorageOut}}-\textcolor{red}{F_{p,t}^{PadStorageIn}}
 
 .. _strategic_model_water_quality_extension:
 
@@ -1070,20 +1070,20 @@ Assumptions:
 
 **Water Quality Sets**
 
-:math:`\textcolor{blue}{w ∈ W}`			                     Water Quality Components (e.g., TDS)
+:math:`\textcolor{blue}{w \in W}`			                     Water Quality Components (e.g., TDS)
 
-:math:`\textcolor{blue}{p^{IntermediateNode} ∈ CP}`			 Intermediate Completions Pad Nodes
+:math:`\textcolor{blue}{p^{IntermediateNode} \in CP}`			 Intermediate Completions Pad Nodes
 
-:math:`\textcolor{blue}{p^{PadStorage} ∈ CP}`			     Pad Storage
+:math:`\textcolor{blue}{p^{PadStorage} \in CP}`			     Pad Storage
 
 
 **Water Quality Parameters**
 
 :math:`\textcolor{green}{v_{l,w,[t]}}` = 	                Water quality at well pad
 
-:math:`\textcolor{green}{ξ_{l,w}^{StorageSite}}` = 	        Initial water quality at storage
+:math:`\textcolor{green}{\xi_{l,w}^{StorageSite}}` = 	        Initial water quality at storage
 
-:math:`\textcolor{green}{ξ_{l,w}^{PadStorage}}` = 	        Initial water quality at pad storage
+:math:`\textcolor{green}{\xi_{l,w}^{PadStorage}}` = 	        Initial water quality at pad storage
 
 
 **Water Quality Variables**
@@ -1091,119 +1091,119 @@ Assumptions:
 :math:`\textcolor{red}{Q_{l,w,t}}` =           Water quality at location
 
 
-**Disposal Site Water Quality** ∀k ∈ K, w ∈ W, t ∈ T
+**Disposal Site Water Quality** :math:`\forall k \in K, w \in W, t \in T`
 
 The water quality of disposed water is dependent on the flow rates into the disposal site and the quality of each of these flows.
 
 .. math::
 
-    ∑_{(n,k)∈NKA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}} +∑_{(s,k)∈SKA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}}+∑_{(r,k)∈RKA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{r,w,t}}
+    \sum\nolimits_{-}{(n,k)\in NKA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}} +\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}}+\sum\nolimits_{-}{(r,k)\in RKA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{r,w,t}}
 
-    +∑_{(s,k)∈SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{s,w,t}}+∑_{(p,k)∈PKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{green}{v_{p,w,[t]}}
+    +\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{s,w,t}}+\sum\nolimits_{-}{(p,k)\in PKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{green}{v_{p,w,[t]}}
 
-    +∑_{(p,k)∈CKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{green}{v_{p,w,[t]}}+∑_{(r,k)∈RKT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{red}{Q_{r,w,t}}
+    +\sum\nolimits_{-}{(p,k)\in CKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{green}{v_{p,w,[t]}}+\sum\nolimits_{-}{(r,k)\in RKT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{red}{Q_{r,w,t}}
 
-    =\textcolor{purple}{F_{k,t}^{DisposalDestination}}⋅\textcolor{red}{Q_{k,w,t}}
+    =\textcolor{purple}{F_{k,t}^{DisposalDestination}} \cdot \textcolor{red}{Q_{k,w,t}}
 
-**Storage Site Water Quality** ∀s ∈ S, w ∈ W, t ∈ T
+**Storage Site Water Quality** :math:`\forall s \in S, w \in W, t \in T`
 
 The water quality at storage sites is dependent on the flow rates into the storage site, the volume of water in storage in the previous time period, and the quality of each of these flows. Even mixing is assumed, so all outgoing flows have the same water quality. If it is the first time period, the initial storage level and initial water quality replaces the water stored and water quality in the previous time period respectively.
 
 .. math::
 
-    \textcolor{green}{λ_{s,t=1}^{Storage}}⋅\textcolor{green}{ξ_{l,w}^{StorageSite}} +\textcolor{purple}{L_{s,t-1}^{Storage}}⋅\textcolor{red}{Q_{s,w,t-1}} +∑_{(n,s)∈NSA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}}
+    \textcolor{green}{\lambda_{s,t=1}^{Storage}} \cdot \textcolor{green}{\xi_{l,w}^{StorageSite}} +\textcolor{purple}{L_{s,t-1}^{Storage}} \cdot \textcolor{red}{Q_{s,w,t-1}} +\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}}
 
-    +∑_{(p,s)∈PST}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{green}{v_{p,w,[t]}} +∑_{(p,s)∈CST}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{green}{v_{p,w,[t]}}
+    +\sum\nolimits_{-}{(p,s)\in PST}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{green}{v_{p,w,[t]}} +\sum\nolimits_{-}{(p,s)\in CST}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{green}{v_{p,w,[t]}}
 
-    = \textcolor{red}{Q_{s,w,t}}⋅(\textcolor{purple}{L_{s,t}^{Storage}} +∑_{(s,n)∈SNA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,p)∈SCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,k)∈SKA}\textcolor{purple}{F_{l,l,t}^{Piped}}
+    = \textcolor{red}{Q_{s,w,t}} \cdot (\textcolor{purple}{L_{s,t}^{Storage}} +\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,k)\in SKA}\textcolor{purple}{F_{l,l,t}^{Piped}}
 
-    +∑_{(s,r)∈SRA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,o)∈SOA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,p)∈SCT}\textcolor{purple}{F_{l,l,t}^{Trucked}}+∑_{(s,k)∈SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}})
+    +\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{purple}{F_{l,l,t}^{Trucked}}+\sum\nolimits_{-}{(s,k)\in SKT}\textcolor{purple}{F_{l,l,t}^{Trucked}})
 
-**Treatment Site Water Quality** ∀r ∈ R, w ∈ W, t ∈ T
+**Treatment Site Water Quality** :math:`\forall r \in R, w \in W, t \in T`
 
 The water quality at treatment sites is dependent on the flow rates into the treatment site, the efficiency of treatment, and the water quality of the flows. Even mixing is assumed, so all outgoing flows have the same water quality. The treatment process does not affect water quality
 
 .. math::
 
-    \textcolor{green}{ϵ_{r,\textcolor{green}{W_{r}^{TreatmentComponent}}}^{Treatment}}⋅(∑_{(n,r)∈NRA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}} +∑_{(s,r)∈SRA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}}
+    \textcolor{green}{\varepsilon_{r,\textcolor{green}{W_{r}^{TreatmentComponent}}}^{Treatment}} \cdot (\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}} +\sum\nolimits_{-}{(s,r)\in SRA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}}
 
-    +∑_{(p,r)∈PRT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{green}{v_{p,w,[t]}} +∑_{(p,r)∈CRT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{green}{v_{p,w,[t]}} )
+    +\sum\nolimits_{-}{(p,r)\in PRT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{green}{v_{p,w,[t]}} +\sum\nolimits_{-}{(p,r)\in CRT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{green}{v_{p,w,[t]}} )
 
-    = \textcolor{red}{Q_{r,w,t}}⋅(∑_{(r,p)∈RCA}\textcolor{purple}{F_{l,l,t}^{Piped}} + \textcolor{purple}{F_{r,t}^{UnusedTreatedWater}})
+    = \textcolor{red}{Q_{r,w,t}} \cdot (\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{purple}{F_{l,l,t}^{Piped}} + \textcolor{purple}{F_{r,t}^{UnusedTreatedWater}})
 
-where :math:`\textcolor{green}{ϵ_{r,w}^{Treatment}}` <1
+where :math:`\textcolor{green}{\varepsilon_{r,w}^{Treatment}}` \le1
 
-**Network Node Water Quality** ∀n ∈ N, w ∈ W, t ∈ T
+**Network Node Water Quality** :math:`\forall n \in N, w \in W, t \in T`
 
 The water quality at nodes is dependent on the flow rates into the node and the water quality of the flows. Even mixing is assumed, so all outgoing flows have the same water quality.
 
 .. math::
 
-    ∑_{(p,n)∈PNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{green}{v_{p,w,[t]}} +∑_{(p,n)∈CNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{green}{v_{p,w,[t]}}
+    \sum\nolimits_{-}{(p,n)\in PNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{green}{v_{p,w,[t]}} +\sum\nolimits_{-}{(p,n)\in CNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{green}{v_{p,w,[t]}}
 
-    +∑_{(n ̃,n)∈NNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}}+∑_{(s,n)∈SNA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}}
+    +\sum\nolimits_{-}{(n TILDETILDETILDE,n)\in NNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}}+\sum\nolimits_{-}{(s,n)\in SNA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}}
 
-    = \textcolor{red}{Q_{n,w,t}}⋅(∑_{(n,n ̃)∈NNA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(n,p)∈NCA}\textcolor{purple}{F_{l,l,t}^{Piped}}
+    = \textcolor{red}{Q_{n,w,t}} \cdot (\sum\nolimits_{-}{(n,n TILDETILDETILDE)\in NNA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,p)\in NCA}\textcolor{purple}{F_{l,l,t}^{Piped}}
 
-    +∑_{(n,k)∈NKA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(n,r)∈NRA}\textcolor{purple}{F_{l,l,t}^{Piped}}
+    +\sum\nolimits_{-}{(n,k)\in NKA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,r)\in NRA}\textcolor{purple}{F_{l,l,t}^{Piped}}
 
-    +∑_{(n,s)∈NSA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(n,o)∈NOA}\textcolor{purple}{F_{l,l,t}^{Piped}})
+    +\sum\nolimits_{-}{(n,s)\in NSA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(n,o)\in NOA}\textcolor{purple}{F_{l,l,t}^{Piped}})
 
 .. admonition:: Water Quality at Completions Pads
 
     Water that is Piped and Trucked to a completions pad is mixed and split into two output streams: Stream (1) goes to the completions pad and stream (2) is input to the completions storage.
     This mixing happens at an intermediate node. Finally, water that meets completions demand comes from two inputs: The first input is output stream (1) from the intermediate step. The second is outgoing flow from the storage tank.
 
-**Completions Pad Intermediate Node Water Quality** ∀p ∈ P, w ∈ W, t ∈ T
+**Completions Pad Intermediate Node Water Quality** :math:`\forall p \in P, w \in W, t \in T`
 
 The water quality at the completions pad intermediate node is dependent on the flow rates of water from outside of the pad to the pad. Even mixing is assumed, so the water to storage and water to completions input have the same water quality.
 
 .. math::
 
-    ∑_{(n,p)∈NCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(p,p)∈PCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+∑_{(s,p)∈SCA}\textcolor{purple}{F_{l,l,t}^{Piped}}
+    \sum\nolimits_{-}{(n,p)\in NCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(p,p)\in PCA}\textcolor{purple}{F_{l,l,t}^{Piped}}+\sum\nolimits_{-}{(s,p)\in SCA}\textcolor{purple}{F_{l,l,t}^{Piped}}
 
-        +∑_{(p,c)∈CCA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(r,p)∈RCA}\textcolor{purple}{F_{l,l,t}^{Piped}} +∑_{(f,p)∈FCA}\textcolor{purple}{F_{l,l,t}^{Sourced}}
+        +\sum\nolimits_{-}{(p,c)\in CCA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(r,p)\in RCA}\textcolor{purple}{F_{l,l,t}^{Piped}} +\sum\nolimits_{-}{(f,p)\in FCA}\textcolor{purple}{F_{l,l,t}^{Sourced}}
 
-        +∑_{(p,p)∈PCT}\textcolor{purple}{F_{l,l,t}^{Trucked}} +∑_{(s,p)∈SCT}\textcolor{purple}{F_{l,l,t}^{Trucked}} +∑_{(p,p)∈CCT}\textcolor{purple}{F_{l,l,t}^{Trucked}}
+        +\sum\nolimits_{-}{(p,p)\in PCT}\textcolor{purple}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(s,p)\in SCT}\textcolor{purple}{F_{l,l,t}^{Trucked}} +\sum\nolimits_{-}{(p,p)\in CCT}\textcolor{purple}{F_{l,l,t}^{Trucked}}
 
-        +∑_{(f,p)∈FCT}\textcolor{purple}{F_{l,l,t}^{Trucked}} = \textcolor{red}{Q_{p^{IntermediateNode},w,t}}⋅ ( \textcolor{purple}{F_{p,t}^{PadStorageIn}} + \textcolor{purple}{F_{p,t}^{CompletionsDestination}})
+        +\sum\nolimits_{-}{(f,p)\in FCT}\textcolor{purple}{F_{l,l,t}^{Trucked}} = \textcolor{red}{Q_{p^{IntermediateNode},w,t}} \cdot ( \textcolor{purple}{F_{p,t}^{PadStorageIn}} + \textcolor{purple}{F_{p,t}^{CompletionsDestination}})
 
 
 
-**Completions Pad Input Node Water Quality** ∀p ∈ P, w ∈ W, t ∈ T
+**Completions Pad Input Node Water Quality** :math:`\forall p \in P, w \in W, t \in T`
 
 The water quality at the completions pad input is dependent on the flow rates of water from pad storage and water from the intermediate node. Even mixing is assumed, so all water into the pad is of the same water quality.
 
 .. math::
 
-    \textcolor{purple}{F_{p,t}^{PadStorageOut}}⋅\textcolor{red}{Q_{p^{PadStorage},w,t}}+\textcolor{purple}{F_{p,t}^{CompletionsDestination}}⋅\textcolor{red}{Q_{p^{IntermediateNode},w,t}}
+    \textcolor{purple}{F_{p,t}^{PadStorageOut}} \cdot \textcolor{red}{Q_{p^{PadStorage},w,t}}+\textcolor{purple}{F_{p,t}^{CompletionsDestination}} \cdot \textcolor{red}{Q_{p^{IntermediateNode},w,t}}
 
-    = \textcolor{red}{Q_{p,w,t}}⋅\textcolor{green}{γ_{p,t}^{Completions}}
+    = \textcolor{red}{Q_{p,w,t}} \cdot \textcolor{green}{\gamma_{p,t}^{Completions}}
 
 
-**Completions Pad Storage Node Water Quality** ∀p ∈ P, w ∈ W, t ∈ T
+**Completions Pad Storage Node Water Quality** :math:`\forall p \in P, w \in W, t \in T`
 
 The water quality at pad storage sites is dependent on the flow rates into the pad storage site, the volume of water in pad storage in the previous time period, and the quality of each of these flows. Even mixing is assumed, so the outgoing flow to completions pad and water in storage at the end of the period have the same water quality. If it is the first time period, the initial storage level and initial water quality replaces the water stored and water quality in the previous time period, respectively.
 
 
 .. math::
 
-    \textcolor{green}{λ_{s,t=1}^{PadStorage}}⋅\textcolor{green}{ξ_{l,w}^{PadStorage}} +\textcolor{purple}{L_{s,t-1}^{PadStorage}}⋅\textcolor{red}{Q_{p^{PadStorage},w,t-1}}
+    \textcolor{green}{\lambda_{s,t=1}^{PadStorage}} \cdot \textcolor{green}{\xi_{l,w}^{PadStorage}} +\textcolor{purple}{L_{s,t-1}^{PadStorage}} \cdot \textcolor{red}{Q_{p^{PadStorage},w,t-1}}
 
-    + \textcolor{purple}{F_{p,t}^{PadStorageIn}} ⋅\textcolor{red}{Q_{p^{IntermediateNode},w}}
+    + \textcolor{purple}{F_{p,t}^{PadStorageIn}} \cdot \textcolor{red}{Q_{p^{IntermediateNode},w}}
 
-    = \textcolor{red}{Q_{p^{PadStorage},w,t}}⋅(\textcolor{purple}{L_{s,t}^{PadStorage}} + \textcolor{purple}{F_{p,t}^{PadStorageOut}} )
+    = \textcolor{red}{Q_{p^{PadStorage},w,t}} \cdot (\textcolor{purple}{L_{s,t}^{PadStorage}} + \textcolor{purple}{F_{p,t}^{PadStorageOut}} )
 
 
-**Beneficial Reuse Water Quality** ∀o ∈ O, w ∈ W, t ∈ T
+**Beneficial Reuse Water Quality** :math:`\forall o \in O, w \in W, t \in T`
 
 The water quality at beneficial reuse sites is dependent on the flow rates into the site and the water quality of the flows.
 
 .. math::
 
-    ∑_{(n,o)∈NOA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{n,w,t}} +∑_{(s,o)∈SOA}\textcolor{purple}{F_{l,l,t}^{Piped}}⋅\textcolor{red}{Q_{s,w,t}} +∑_{(p,o)∈POT}\textcolor{purple}{F_{l,l,t}^{Trucked}}⋅\textcolor{green}{v_{p,w,[t]}}
+    \sum\nolimits_{-}{(n,o)\in NOA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{n,w,t}} +\sum\nolimits_{-}{(s,o)\in SOA}\textcolor{purple}{F_{l,l,t}^{Piped}} \cdot \textcolor{red}{Q_{s,w,t}} +\sum\nolimits_{-}{(p,o)\in POT}\textcolor{purple}{F_{l,l,t}^{Trucked}} \cdot \textcolor{green}{v_{p,w,[t]}}
 
-    = \textcolor{red}{Q_{o,w,t}}⋅\textcolor{purple}{F_{o,t}^{BeneficialReuseDestination}}
+    = \textcolor{red}{Q_{o,w,t}} \cdot \textcolor{purple}{F_{o,t}^{BeneficialReuseDestination}}
 
 
 .. _strategic_model_terminology:


### PR DESCRIPTION
## Resolves #137

## Motivation

- Unicode characters in `.rst` source files are not supported by the default LaTeX builder used by Sphinx
- This in turn results in failure and/or invalid output in the PDF file that's automatically generated by ReadTheDocs
- In general, it makes sense for us to be consistent in how we write math formulas, and since we have to use LaTeX syntax anyway, we might as well use the LaTeX syntax for everything

## Summary

- Replace all Unicode characters in the `.rst` source files with their LaTeX equivalent

## For reviewers

- I used [a script](https://gist.github.com/lbianchi-lbl/c467a657074e21fb053d5eaf35252610#file-texify-py=) to do this, and I've taken a cursory look to see that the output before and after the conversion matched; however, it's important that someone with more (i.e. any) domain expertise than myself checks more carefully to ensure that something hasn't been "lost in conversion"
- This is effectively the complete opposite of #138 (I was trying both strategies in parallel to fix the PDF build issues), which configures the LaTeX builder to make it compatible with Unicode characters
  - We can merge #138 in as an interim solution to get the RTD PDF builds to work while we review this, and merge this in once we're confident that the LaTeX-ified version of the docs is OK

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
