### PR TITLE
Strategic model - add convert default value for p_pi_Trucking from user units to model units

### DIFF
--- a/pareto/strategic_water_management/strategic_produced_water_optimization.py
+++ b/pareto/strategic_water_management/strategic_produced_water_optimization.py
@@ -1732,7 +1732,11 @@ def create_model(df_sets, df_parameters, default={}):
     # be confusing
     model.p_pi_Trucking = Param(
         model.s_L,
-        default=max(model.df_parameters["TruckingHourlyCost"].values()) * 100
+        default=pyunits.convert_value(
+            max(model.df_parameters["TruckingHourlyCost"].values()) * 100,
+            from_units=model.user_units["currency"],
+            to_units=model.model_units["currency"],
+        )
         if model.df_parameters["TruckingHourlyCost"]
         else pyunits.convert_value(
             15000,

--- a/pareto/strategic_water_management/strategic_produced_water_optimization.py
+++ b/pareto/strategic_water_management/strategic_produced_water_optimization.py
@@ -1727,30 +1727,27 @@ def create_model(df_sets, df_parameters, default={}):
         units=model.model_units["currency_volume"],
         doc="Pipeline operational cost [currency/volume]",
     )
+    TruckingHourlyCost_convert_to_model = {
+        key: pyunits.convert_value(
+            value,
+            from_units=model.user_units["currency"],
+            to_units=model.model_units["currency"],
+        )
+        for key, value in model.df_parameters["TruckingHourlyCost"].items()
+    }
     # COMMENT: For this parameter only currency units are defined, as the hourly rate is canceled out with the
     # trucking time units from parameter p_Tau_Trucking. This is to avoid adding an extra unit for time which may
     # be confusing
     model.p_pi_Trucking = Param(
         model.s_L,
-        default=pyunits.convert_value(
-            max(model.df_parameters["TruckingHourlyCost"].values()) * 100,
-            from_units=model.user_units["currency"],
-            to_units=model.model_units["currency"],
-        )
-        if model.df_parameters["TruckingHourlyCost"]
+        default=max(TruckingHourlyCost_convert_to_model.values()) * 100
+        if TruckingHourlyCost_convert_to_model
         else pyunits.convert_value(
             15000,
-            from_units=model.user_units["currency"],
+            from_units=pyunits.USD,
             to_units=model.model_units["currency"],
         ),
-        initialize={
-            key: pyunits.convert_value(
-                value,
-                from_units=model.user_units["currency"],
-                to_units=model.model_units["currency"],
-            )
-            for key, value in model.df_parameters["TruckingHourlyCost"].items()
-        },
+        initialize=TruckingHourlyCost_convert_to_model,
         units=model.model_units["currency"],
         doc="Trucking hourly cost (by source) [currency/hr]",
     )


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

In the strategic model, added a call to `pyunits.convert_value` to convert the default value for trucking hourly cost (`p_pi_Trucking`) from user units to model units.

Resolves #182 

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
