### PR TITLE
Use plotly version 5.11.0 (since 5.12.0 breaks tests)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
         # for the moment mainly for getting solvers with `idaes get-extensions`
         "idaes-pse",
         "requests",
-        "plotly",
+        "plotly==5.11.0",
         "kaleido",
     ],
     extras_require={


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:
Plotly version 5.12.0 breaks our tests, so use 5.11.0 instead.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
