### PR TITLE
New output tab to summarize CAPEX buildout

### DIFF
--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -27,7 +27,7 @@ MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
     "pareto/strategic_water_management/strategic_produced_water_optimization.py": 372,
     "pareto/tests/test_operational_model.py": 15,
     "pareto/utilities/get_data.py": 24,
-    "pareto/utilities/results.py": 157,
+    "pareto/utilities/results.py": 173,
     "pareto/tests/test_strategic_model.py": 50,
     "pareto/tests/test_solvers.py": 31,
     "pareto/tests/test_plot_scatter.py": 8,

--- a/pareto/utilities/results.py
+++ b/pareto/utilities/results.py
@@ -19,6 +19,9 @@ from pareto.operational_water_management.operational_produced_water_optimization
     ProdTank,
     WaterQuality,
 )
+from pareto.strategic_water_management.strategic_produced_water_optimization import (
+    PipelineCost,
+)
 from pyomo.environ import Var, units as pyunits, value
 import plotly.graph_objects as go
 import plotly.express as px
@@ -120,6 +123,16 @@ def generate_report(
 
         headers = {
             "v_F_Overview_dict": [("Variable Name", "Documentation", "Unit", "Total")],
+            "vb_y_overview_dict": [
+                (
+                    "CAPEX Type",
+                    "Location",
+                    "Destination",
+                    "Capacity",
+                    "Unit",
+                    "Technology",
+                )
+            ],
             "v_F_Piped_dict": [("Origin", "Destination", "Time", "Piped water")],
             "v_C_Piped_dict": [("Origin", "Destination", "Time", "Cost piping")],
             "v_F_Trucked_dict": [("Origin", "Destination", "Time", "Trucked water")],
@@ -778,6 +791,129 @@ def generate_report(
                     var_value = model.p_discrete_quality[i[2], i[3]].value
                 if i is not None and var_value is not None and var_value > 0:
                     headers[str(variable.name) + "_dict"].append((*i, var_value))
+
+    # region Create CAPEX summary (Infrastructure Buildout) tab for strategic model
+    if "vb_y_overview_dict" in headers:
+        # "vb_y_Treatment"
+        treatment_data = model.vb_y_Treatment._data
+        # get units
+        from_unit_string = model.p_delta_Treatment.get_units().to_string()
+        # the display units (to_unit) is defined by output_units from module parameter
+        if output_units == OutputUnits.unscaled_model_units:
+            to_unit = model.model_to_unscaled_model_display_units[from_unit_string]
+        elif output_units == OutputUnits.user_units:
+            to_unit = model.model_to_user_units[from_unit_string]
+        for i in treatment_data:
+            # add values to output dictionary
+            if (
+                treatment_data[i].value == 1
+                and model.p_delta_Treatment[(i[1], i[2])].value > 0
+            ):
+                capacity = pyunits.convert_value(
+                    model.p_delta_Treatment[(i[1], i[2])].value,
+                    from_units=model.p_delta_Treatment.get_units(),
+                    to_units=to_unit,
+                )
+                headers["vb_y_overview_dict"].append(
+                    (
+                        "Treatment Facility",
+                        i[0],
+                        "--",
+                        capacity,
+                        to_unit.to_string().replace("oil_bbl", "bbl"),
+                        i[1],
+                    )
+                )
+
+        # vb_y_Disposal
+        disposal_data = model.vb_y_Disposal._data
+        # get units
+        from_unit_string = model.p_delta_Disposal.get_units().to_string()
+        # the display units (to_unit) is defined by output_units from module parameter
+        if output_units == OutputUnits.unscaled_model_units:
+            to_unit = model.model_to_unscaled_model_display_units[from_unit_string]
+        elif output_units == OutputUnits.user_units:
+            to_unit = model.model_to_user_units[from_unit_string]
+        for i in disposal_data:
+            # add values to output dictionary
+            if disposal_data[i].value == 1 and model.p_delta_Disposal[i[1]].value > 0:
+                capacity = pyunits.convert_value(
+                    model.p_delta_Disposal[i[1]].value,
+                    from_units=model.p_delta_Disposal.get_units(),
+                    to_units=to_unit,
+                )
+                headers["vb_y_overview_dict"].append(
+                    (
+                        "Disposal Facility",
+                        i[0],
+                        "--",
+                        capacity,
+                        to_unit.to_string().replace("oil_bbl", "bbl"),
+                        "--",
+                    )
+                )
+
+        # vb_y_Storage
+        storage_data = model.vb_y_Storage._data
+        # get units
+        from_unit_string = model.p_delta_Storage.get_units().to_string()
+        # the display units (to_unit) is defined by output_units from module parameter
+        if output_units == OutputUnits.unscaled_model_units:
+            to_unit = model.model_to_unscaled_model_display_units[from_unit_string]
+        elif output_units == OutputUnits.user_units:
+            to_unit = model.model_to_user_units[from_unit_string]
+        for i in storage_data:
+            # add values to output dictionary
+            if storage_data[i].value == 1 and model.p_delta_Storage[i[1]].value > 0:
+                capacity = pyunits.convert_value(
+                    model.p_delta_Storage[i[1]].value,
+                    from_units=model.p_delta_Storage.get_units(),
+                    to_units=to_unit,
+                )
+                headers["vb_y_overview_dict"].append(
+                    (
+                        "Storage Facility",
+                        i[0],
+                        "--",
+                        capacity,
+                        to_unit.to_string().replace("oil_bbl", "bbl"),
+                        "--",
+                    )
+                )
+
+        # vb_y_Pipeline
+        if model.config.pipeline_cost == PipelineCost.distance_based:
+            capacity_variable = model.p_mu_Pipeline
+        elif model.config.pipeline_cost == PipelineCost.capacity_based:
+            capacity_variable = model.p_delta_Pipeline
+        pipeline_data = model.vb_y_Pipeline._data
+        # get units
+        from_unit_string = capacity_variable.get_units().to_string()
+        # the display units (to_unit) is defined by output_units from module parameter
+        if output_units == OutputUnits.unscaled_model_units:
+            to_unit = model.model_to_unscaled_model_display_units[from_unit_string]
+        elif output_units == OutputUnits.user_units:
+            to_unit = model.model_to_user_units[from_unit_string]
+        for i in pipeline_data:
+            # add values to output dictionary only if non-zero capacity is selected
+            if pipeline_data[i].value == 1 and capacity_variable[i[2]].value > 0:
+                capacity = pyunits.convert_value(
+                    capacity_variable[i[2]].value,
+                    from_units=capacity_variable.get_units(),
+                    to_units=to_unit,
+                )
+                headers["vb_y_overview_dict"].append(
+                    (
+                        "Pipeline Construction",
+                        i[0],
+                        i[1],
+                        capacity,
+                        to_unit.to_string().replace("oil_bbl", "bbl"),
+                        "--",
+                    )
+                )
+
+    # endregion
 
     if model.v_C_Slack.value is not None and model.v_C_Slack.value > 0:
         print("!!!ATTENTION!!! One or several slack variables have been triggered!")


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Addresses Issue #193 . Goal is to create a new tab in the report output that summarizes Treatment, Pipeline, Disposal, and Storage CAPEX. 
![image](https://user-images.githubusercontent.com/91741082/213536486-0db21e6f-64f4-4d5d-a2b2-6e5ea6d1b84b.png)


## Changes proposed in this PR:
-add new tab "vb_y_overview" that contains non-zero selected capacity expansion

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
