### PR TITLE
check HTTP status code before attempting to decode JSON

### DIFF
--- a/pareto/utilities/get_data.py
+++ b/pareto/utilities/get_data.py
@@ -598,7 +598,11 @@ def od_matrix(inputs):
             + destination_index
             + "&annotations=duration,distance"
         )
-        response_json = response.json()
+        if response.ok:
+            # Ensure HTTP Status code is less than 400
+            response_json = response.json()
+        else:
+            raise Warning("Error when requesting data, make sure your coordinates are correct")
 
         df_times = pd.DataFrame(
             index=list(origin.keys()), columns=list(destination.keys())
@@ -662,7 +666,12 @@ def od_matrix(inputs):
         response = requests.post(
             api_url_base + "key=" + api_key, headers=header, json=data
         )
-        response_json = response.json()
+        if response.ok:
+            # Ensure HTTP Status code is less than 400
+            response_json = response.json()
+        else:
+            raise Warning("Error when requesting data, make sure your API key and coordinates"
+                          " are correct")
 
         # Definition of two empty dataframes that will contain drive times and distances.
         # These dataframes wiil be exported to an Excel workbook

--- a/pareto/utilities/get_data.py
+++ b/pareto/utilities/get_data.py
@@ -602,7 +602,9 @@ def od_matrix(inputs):
             # Ensure HTTP Status code is less than 400
             response_json = response.json()
         else:
-            raise Warning("Error when requesting data, make sure your coordinates are correct")
+            raise Warning(
+                "Error when requesting data, make sure your coordinates are correct"
+            )
 
         df_times = pd.DataFrame(
             index=list(origin.keys()), columns=list(destination.keys())
@@ -670,8 +672,10 @@ def od_matrix(inputs):
             # Ensure HTTP Status code is less than 400
             response_json = response.json()
         else:
-            raise Warning("Error when requesting data, make sure your API key and coordinates"
-                          " are correct")
+            raise Warning(
+                "Error when requesting data, make sure your API key and coordinates"
+                " are correct"
+            )
 
         # Definition of two empty dataframes that will contain drive times and distances.
         # These dataframes wiil be exported to an Excel workbook


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Pareto offers the capability of obtaining drive distances/times from Maps API providers. This information is obtained by querying HTTP endpoints for two service providers (Bing, Open Street Maps). In case these queries fail, the code crashes

## Changes proposed in this PR:
- Check the status of HTTP responses obtained before attempting to decode the response JSON

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
