### PR TITLE
Infrastructure Buildout Bug Fix

### DIFF
--- a/.stagedfright/checks.py
+++ b/.stagedfright/checks.py
@@ -27,7 +27,7 @@ MAP_PATH_EXPECTED_HARDCODED_DATA_COUNT = {
     "pareto/strategic_water_management/strategic_produced_water_optimization.py": 375,
     "pareto/tests/test_operational_model.py": 15,
     "pareto/utilities/get_data.py": 24,
-    "pareto/utilities/results.py": 176,
+    "pareto/utilities/results.py": 181,
     "pareto/tests/test_strategic_model.py": 54,
     "pareto/tests/test_solvers.py": 31,
     "pareto/tests/test_plot_scatter.py": 8,

--- a/pareto/strategic_water_management/run_strategic_model.py
+++ b/pareto/strategic_water_management/run_strategic_model.py
@@ -109,7 +109,7 @@ parameter_list = [
 # note the double backslashes '\\' in that path reference
 with resources.path(
     "pareto.case_studies",
-    "strategic_Feb_stakeholder_simplified_midland.xlsx",
+    "strategic_treatment_demo.xlsx",
 ) as fpath:
     [df_sets, df_parameters] = get_data(fpath, set_list, parameter_list)
 

--- a/pareto/strategic_water_management/run_strategic_model.py
+++ b/pareto/strategic_water_management/run_strategic_model.py
@@ -109,7 +109,7 @@ parameter_list = [
 # note the double backslashes '\\' in that path reference
 with resources.path(
     "pareto.case_studies",
-    "strategic_treatment_demo.xlsx",
+    "strategic_Feb_stakeholder_simplified_midland.xlsx",
 ) as fpath:
     [df_sets, df_parameters] = get_data(fpath, set_list, parameter_list)
 

--- a/pareto/utilities/results.py
+++ b/pareto/utilities/results.py
@@ -396,6 +396,10 @@ def generate_report(
             reuseDemand_value = 0
         model.reuse_CompletionsDemandKPI.value = reuseDemand_value
 
+        # Infrastructure buildout table
+
+        # Due to tolerances, binaries may not exactly equal 1
+        binary_epsilon = 0.005
         # "vb_y_Treatment"
         treatment_data = model.vb_y_Treatment._data
         # get units
@@ -408,7 +412,8 @@ def generate_report(
         for i in treatment_data:
             # add values to output dictionary
             if (
-                treatment_data[i].value == 1
+                treatment_data[i].value >= 1 - binary_epsilon
+                and treatment_data[i].value <= 1 + binary_epsilon
                 and model.p_delta_Treatment[(i[1], i[2])].value > 0
             ):
                 capacity = pyunits.convert_value(
@@ -438,7 +443,11 @@ def generate_report(
             to_unit = model.model_to_user_units[from_unit_string]
         for i in disposal_data:
             # add values to output dictionary
-            if disposal_data[i].value == 1 and model.p_delta_Disposal[i[1]].value > 0:
+            if (
+                disposal_data[i].value >= 1 - binary_epsilon
+                and disposal_data[i].value <= 1 + binary_epsilon
+                and model.p_delta_Disposal[i[1]].value > 0
+            ):
                 capacity = pyunits.convert_value(
                     model.p_delta_Disposal[i[1]].value,
                     from_units=model.p_delta_Disposal.get_units(),
@@ -466,7 +475,11 @@ def generate_report(
             to_unit = model.model_to_user_units[from_unit_string]
         for i in storage_data:
             # add values to output dictionary
-            if storage_data[i].value == 1 and model.p_delta_Storage[i[1]].value > 0:
+            if (
+                storage_data[i].value >= 1 - binary_epsilon
+                and storage_data[i].value <= 1 + binary_epsilon
+                and model.p_delta_Storage[i[1]].value > 0
+            ):
                 capacity = pyunits.convert_value(
                     model.p_delta_Storage[i[1]].value,
                     from_units=model.p_delta_Storage.get_units(),
@@ -498,7 +511,11 @@ def generate_report(
             to_unit = model.model_to_user_units[from_unit_string]
         for i in pipeline_data:
             # add values to output dictionary only if non-zero capacity is selected
-            if pipeline_data[i].value == 1 and capacity_variable[i[2]].value > 0:
+            if (
+                pipeline_data[i].value >= 1 - binary_epsilon
+                and pipeline_data[i].value <= 1 + binary_epsilon
+                and capacity_variable[i[2]].value > 0
+            ):
                 capacity = pyunits.convert_value(
                     capacity_variable[i[2]].value,
                     from_units=capacity_variable.get_units(),


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

In some instances, it was reported that the CAPEX Infrastructure buildout table missed some the of the pipelines shown in the individual CAPEX type tabs. This is likely due to tolerances in the binaries. 

## Changes proposed in this PR:
- When creating the infrastructure buildout table, when checking the binary, instead of using an equality check ( == 1), include a tolerance (>= 1 - tolerance and <= 1 + tolerance)

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
