### PR TITLE
fixing the indexing of constraints when using model.s_LLA or s_LLT

### DIFF
--- a/pareto/strategic_water_management/strategic_produced_water_optimization.py
+++ b/pareto/strategic_water_management/strategic_produced_water_optimization.py
@@ -5078,13 +5078,11 @@ def create_model(df_sets, df_parameters, default={}):
 
     def ReuseDestinationDeliveriesRule(model, p, t):
         constraint = model.v_F_ReuseDestination[p, t] == sum(
-            model.v_F_Piped[l, l_tilde, t]
-            for (l, l_tilde) in model.s_LLA
-            if (l_tilde == p) and (l not in model.s_F)
+            model.v_F_Piped[l, p, t]
+            for l in (model.s_L - model.s_F) if (l, p) in model.s_LLA
         ) + sum(
-            model.v_F_Trucked[l, l_tilde, t]
-            for (l, l_tilde) in model.s_LLT
-            if (l_tilde == p) and (l not in model.s_F)
+            model.v_F_Trucked[l, p, t]
+            for l in (model.s_L - model.s_F) if (l, p) in model.s_LLT
         )
 
         return process_constraint(constraint)
@@ -5098,9 +5096,9 @@ def create_model(df_sets, df_parameters, default={}):
 
     def DisposalDestinationDeliveriesRule(model, k, t):
         constraint = model.v_F_DisposalDestination[k, t] == sum(
-            model.v_F_Piped[l, k, t] for (l, l_tilde) in model.s_LLA if l_tilde == k
+            model.v_F_Piped[l, k, t] for l in model.s_L if (l, k) in model.s_LLA
         ) + sum(
-            model.v_F_Trucked[l, k, t] for (l, l_tilde) in model.s_LLT if l_tilde == k
+            model.v_F_Trucked[l, k, t] for l in model.s_L if (l, k) in model.s_LLT
         )
 
         return process_constraint(constraint)

--- a/pareto/strategic_water_management/strategic_produced_water_optimization.py
+++ b/pareto/strategic_water_management/strategic_produced_water_optimization.py
@@ -5079,10 +5079,12 @@ def create_model(df_sets, df_parameters, default={}):
     def ReuseDestinationDeliveriesRule(model, p, t):
         constraint = model.v_F_ReuseDestination[p, t] == sum(
             model.v_F_Piped[l, p, t]
-            for l in (model.s_L - model.s_F) if (l, p) in model.s_LLA
+            for l in (model.s_L - model.s_F)
+            if (l, p) in model.s_LLA
         ) + sum(
             model.v_F_Trucked[l, p, t]
-            for l in (model.s_L - model.s_F) if (l, p) in model.s_LLT
+            for l in (model.s_L - model.s_F)
+            if (l, p) in model.s_LLT
         )
 
         return process_constraint(constraint)
@@ -5097,9 +5099,7 @@ def create_model(df_sets, df_parameters, default={}):
     def DisposalDestinationDeliveriesRule(model, k, t):
         constraint = model.v_F_DisposalDestination[k, t] == sum(
             model.v_F_Piped[l, k, t] for l in model.s_L if (l, k) in model.s_LLA
-        ) + sum(
-            model.v_F_Trucked[l, k, t] for l in model.s_L if (l, k) in model.s_LLT
-        )
+        ) + sum(model.v_F_Trucked[l, k, t] for l in model.s_L if (l, k) in model.s_LLT)
 
         return process_constraint(constraint)
 


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:
This PR fixes the indexing of 2 constraints when using `s_LLA `and `s_LLT `sets. Specifically, it removes a redundant index used for summing over 2 indices to correctly reflect the summation over 1 index and looping over another.


## Changes proposed in this PR:
The two constraints affected are 
- `ReuseDestinationDeliveriesRule`
- `DisposalDestinationDeliveriesRule`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
