### PR TITLE
Fix strategic model documentation typos

### DIFF
--- a/docs/model_library/strategic_water_management/index.rst
+++ b/docs/model_library/strategic_water_management/index.rst
@@ -802,7 +802,7 @@ At a treatment facility, the input treatment feed is treated and separated into 
         + \textcolor{red}{F_{r,t}^{TreatedWater}}
 
 
-**Residual Water:** :math:`\forall \textcolor{blue}{r \in R}, \textcolor{blue}{b \in B}, \textcolor{blue}{t \in T}`
+**Residual Water:** :math:`\forall \textcolor{blue}{r \in R}, \textcolor{blue}{wt \in WT}, \textcolor{blue}{t \in T}`
 
 The efficiency of a treatment technology determines the amount of residual water produced.
 
@@ -1119,7 +1119,7 @@ Alternatively, if it is desired to only consider sizes to build, the 0th case ca
 
 .. math::
 
-    \sum_{j \in J, b \in B}\textcolor{red}{y_{r,wt,j}^{Treatment}} = 1
+    \sum_{j \in J, wt \in WT}\textcolor{red}{y_{r,wt,j}^{Treatment}} = 1
 
 
 **Logic Constraints for Desalination:**


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Replace some lingering instances of the set B in the strategic model documentation with the updated name WT.

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
