### PR TITLE
Add dependencies removed in IDAES 2.1

### DIFF
--- a/pareto/tests/test_headers.py
+++ b/pareto/tests/test_headers.py
@@ -19,8 +19,8 @@ import os
 
 # third-party
 import pytest
-import yaml
 
+yaml = pytest.importorskip("yaml", reason="pyyaml not available")
 _ = pytest.importorskip("addheader", reason="addheader not available")
 from addheader.add import FileFinder, detect_files
 

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ setup(
         "testing": [
             "pytest",
             "packaging",  # packaging is already a dependency of pytest, but we specify it here just in case
+            "pyyaml",
         ],
     },
     include_package_data=True,


### PR DESCRIPTION
## Motivation

IDAES 2.1 removed some dependencies that are now causing our CI runs to fail.

## Changes proposed in this PR:
- Add pyyaml as testing dependency and skip test if missing

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
