### PR TITLE
remove duplicated units from the header due to multiple calls

### DIFF
--- a/pareto/utilities/results.py
+++ b/pareto/utilities/results.py
@@ -918,20 +918,6 @@ def generate_report(
             to_unit = variable.get_units()
         else:
             to_unit = None
-        # if variable data is not none and indexed, update headers to display unit
-        if (
-            len(variable._data) > 1
-            and list(variable._data.keys())[0] is not None
-            and to_unit is not None
-        ):
-            header = list(headers[str(variable.name) + "_dict"][0])
-            header[-1] = (
-                headers[str(variable.name) + "_dict"][0][-1]
-                + " ["
-                + to_unit.to_string().replace("oil_bbl", "bbl")
-                + "]"
-            )
-            headers[str(variable.name) + "_dict"][0] = tuple(header)
         if variable._data is not None:
             # Loop through the indices of a variable. "i" is a tuple of indices
             for i in variable._data:


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:
This PR removes multiple prints of units in the header of the results file

## Changes proposed in this PR:
- removed a duplicate section of code that caused the units to print twice
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
