### PR TITLE
Enable Black formatting for Jupyter notebooks

### DIFF
--- a/pareto/examples/strategic_model_general_demo/strategic_model_general_demo.ipynb
+++ b/pareto/examples/strategic_model_general_demo/strategic_model_general_demo.ipynb
@@ -246,7 +246,7 @@
     "\n",
     "print(\"\\n------- Desalination technologies -------\")\n",
     "print(type(df_parameters[\"DesalinationTechnologies\"]))\n",
-    "print(   df_parameters[\"DesalinationTechnologies\"])"
+    "print(df_parameters[\"DesalinationTechnologies\"])"
    ]
   },
   {

--- a/pareto/examples/strategic_model_general_demo/strategic_model_general_demo.ipynb
+++ b/pareto/examples/strategic_model_general_demo/strategic_model_general_demo.ipynb
@@ -246,7 +246,7 @@
     "\n",
     "print(\"\\n------- Desalination technologies -------\")\n",
     "print(type(df_parameters[\"DesalinationTechnologies\"]))\n",
-    "print(df_parameters[\"DesalinationTechnologies\"])"
+    "print(   df_parameters[\"DesalinationTechnologies\"])"
    ]
   },
   {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 pytest==6.2.*
 pytest-cov
-black==22.3.0
+black[jupyter]==22.3.0
 pre-commit==2.16.*
 sphinx
 myst-parser[linkify]


### PR DESCRIPTION
## Resolves #263 

## Changes proposed in this PR:

- Add `[jupyter]` optional dependency for `black` dev requirement

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
