### PR TITLE
Hydraulics linearization

### DIFF
--- a/docs/model_library/Hydraulics/index.rst
+++ b/docs/model_library/Hydraulics/index.rst
@@ -215,3 +215,111 @@ Allows pumping only if a pump exists in a pipeline.
         + \textcolor{green}{\nu^{Electricity}} \cdot \textcolor{green}{\rho.g} \cdot \sum_{t \in T}\textcolor{red}{H_{l,\tilde{l},t}^{Pump}} \cdot \textcolor{red}{F_{l,\tilde{l},t}^{Piped}}
 
 
+    **Linearizing the Equations/constraints specific to the co_optimize method**
+
+    **Parameters**
+    :math:`\textcolor{green}{\Delta_I}` =                        Length of interval of flows for building piecewise linear model
+    :math:`M` =                       Large enough constant (maximum pressure change)
+
+    **Binary Variables**
+
+    :math:`\textcolor{red}{z_{l,\tilde{l},t, i}}, i\in \{0,1,2,..., \lceil \log_2(70000/\Delta_I) \rceil\}`:   Intermediate binary variables to determine the section of the piecewise linear graph 
+
+    **Continuous Variables**
+
+    :math:`\textcolor{red}{\lambda_{l,\tilde{l},t, i}}, i\in \{0,1,2,..., \lceil 70000/\Delta_I \rceil\}`  Intermediate continuous variables, convex combination multipliers
+
+    :math:`\textcolor{red}{term_{l,\tilde{l},t}}`  Continuous variables for flow raised to the power 1.85 (in RHS of Hazen-Williams)
+
+    :math:`\textcolor{red}{term2_{l,\tilde{l},t, d}}`  Continuous variables for the product of pressure drop and binary to select diameter (in LHS of Hazen-Williams)
+
+    **Effective diameter rule:** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}`
+
+    We remove this constraint. When effective diameter is required, we would use the expression of binaries.
+
+    **Setting term in RHS:** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}, \textcolor{blue}{t \in T}`
+
+    Set the right hand side term flow to the power 1.85 in Hazen-Williams equation
+
+    .. math::
+
+        \textcolor{red}{F_{l,\tilde{l},t}^{Piped}}
+        = \sum_{i \in \{0,1,2,..,\lceil 70000/\Delta_I \rceil\}}i \cdot \Delta_I \cdot \textcolor{red}{\lambda_{l, \tilde{l}, t, i}}
+
+    .. math::
+
+        \textcolor{red}{term_{l,\tilde{l},t}}
+        = \sum_{i \in \{0,1,2,..,\lceil 70000/\Delta_I \rceil\}}(1.84E-6 \cdot i \cdot \Delta_I)^{1.85} \cdot \textcolor{red}{\lambda_{l,\tilde{l},t, i}}
+
+    **Sum of convex multipliers is one** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}, \textcolor{blue}{t \in T}`
+
+
+    .. math::
+
+       \sum_{i \in \{0,1,2,..,\lceil 70000/\Delta_I \rceil\}} \textcolor{red}{\lambda_{l,\tilde{l},t, i}} = 1
+
+    **Only two convex multipliers are non-zero** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}, \textcolor{blue}{t \in T} j \in \textcolor{blue}{\{0,1,2,..,\lceil 70000/\Delta_I \rceil-1\}}`
+
+    c(k) = binary representation of number k of length :math:`\lceil log_2(70000/\Delta_I) \rceil\}`
+    .. math::
+       \sum_{i \in \{0,1,2,..,\lceil 70000/\Delta_I \rceil\}, i \neq j, j+1} \textcolor{red}{\lambda_{l,\tilde{l},t, i}} = \sum_{i \in \{0,1,2,..,\lceil log_2(70000/\Delta_I)\rceil\}, i\in Supp(c(j))}1-\textcolor{red}{z_{l,\tilde{l},t, i}} +\
+       \sum_{i \in \{0,1,2,..,\lceil log_2(70000/\Delta_I)\rceil\}, i \notin Supp(c(j))}\textcolor{red}{z_{l,\tilde{l},t, i}} }
+
+
+    
+    **Setting term in LHS:** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}, \textcolor{blue}{t \in T}\textcolor{blue}{d \in D}`
+
+    Set the product of pressure change and binary diameter selection variables by the following set of constraints
+
+    .. math::
+
+        \textcolor{red}{term2_{l,\tilde{l},t,d}} \leq \textcolor{red}{H_{l,\tilde{l},t}^{Friction, HW}}
+
+    .. math::
+
+        \textcolor{red}{term2_{l,\tilde{l},t,d}} \leq  M \cdot \textcolor{red}{y^{Pipeline}_{l,\tilde{l}, d}}
+
+    .. math::
+
+        \textcolor{red}{term2_{l,\tilde{l},t,d}} \geq \textcolor{red}{H_{l,\tilde{l},t}^{Friction, HW}}  - M \cdot (1 - \textcolor{red}{y^{Pipeline}_{l,\tilde{l}, d}}) 
+
+    **Hazen-Williams based frictional head loss calculation:** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}, \textcolor{blue}{t \in T}`
+
+    Calculate head loss using Hazen-Williams equation. Note that units for all terms in this equation are in SI units so, appropriate conversion factors must be added.
+
+    .. math::
+
+      \sum{d \in D}\textcolor{red}{term2_{l,\tilde{l},t,d}} \cdot (d)^{4.87}
+        = 10.704 \cdot \textcolor{red}{term_{l,\tilde{l},t}^{Piped}} / (\textcolor{green}{\iota^{CHW}})^{1.85} \cdot \textcolor{green}{\lambda_{l,\tilde{l}}^{Pipeline}}
+
+    **Node pressure rule:** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}, \textcolor{blue}{t \in T}`
+
+    Pressure constraint based on Bernoulli's energy balance equation.
+
+    .. math::
+
+        \textcolor{blue}{\tilde{l},l \in LLA}
+        \textcolor{red}{P_{l,t}} + \textcolor{green}{\zeta_{l}} \cdot \textcolor{green}{\rho.g}
+         = \textcolor{red}{P_{\tilde{l},t}} + \textcolor{green}{\zeta_{\tilde{l}}} \cdot \textcolor{green}{\rho.g}
+         + \textcolor{red}{H_{l,\tilde{l},t}^{Friction, HW}} \cdot \textcolor{green}{\rho.g}
+         - \textcolor{red}{H_{\tilde{l},l,t}^{Friction, HW}} \cdot \textcolor{green}{\rho.g}
+         - \textcolor{red}{H_{l,\tilde{l},t}^{Pump}} \cdot \textcolor{green}{\rho.g}
+         + \textcolor{red}{H_{l,\tilde{l},t}^{Valve}} \cdot \textcolor{green}{\rho.g}
+
+    .. math::
+         \textcolor{blue}{\tilde{l},l \notin LLA}
+        \textcolor{red}{P_{l,t}} + \textcolor{green}{\zeta_{l}} \cdot \textcolor{green}{\rho.g}
+         = \textcolor{red}{P_{\tilde{l},t}} + \textcolor{green}{\zeta_{\tilde{l}}} \cdot \textcolor{green}{\rho.g}
+         + \textcolor{red}{H_{l,\tilde{l},t}^{Friction, HW}} \cdot \textcolor{green}{\rho.g}
+         - \textcolor{red}{H_{l,\tilde{l},t}^{Pump}} \cdot \textcolor{green}{\rho.g}
+         + \textcolor{red}{H_{l,\tilde{l},t}^{Valve}} \cdot \textcolor{green}{\rho.g}
+
+    **Pump cost rule:** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}`
+
+    Allows pumping only if a pump exists in a pipeline.
+
+    .. math::
+
+        \textcolor{red}{C_{l,\tilde{l}}^{Pump}} = \textcolor{green}{\nu^{Pump}} \cdot \textcolor{red}{y_{l,\tilde{l},[t]}^{Pump}}
+        + \textcolor{green}{\nu^{Electricity}} \cdot \textcolor{green}{\rho.g} \cdot \sum_{t \in T}1609 \cdot \textcolor{red}{F_{l,\tilde{l},t}^{Piped}}
+

--- a/docs/model_library/Hydraulics/index.rst
+++ b/docs/model_library/Hydraulics/index.rst
@@ -189,12 +189,21 @@ Allows pumping only if a pump exists in a pipeline.
 
     .. math::
 
+        \textcolor{blue}{\tilde{l},l \in LLA}
         \textcolor{red}{P_{l,t}} + \textcolor{green}{\zeta_{l}} \cdot \textcolor{green}{\rho.g}
          = \textcolor{red}{P_{\tilde{l},t}} + \textcolor{green}{\zeta_{\tilde{l}}} \cdot \textcolor{green}{\rho.g}
          + \textcolor{red}{H_{l,\tilde{l},t}^{Friction, HW}} \cdot \textcolor{green}{\rho.g}
-         + \textcolor{red}{H_{l,\tilde{l},t}^{Pump}} \cdot \textcolor{green}{\rho.g}
-         - \textcolor{red}{H_{l,\tilde{l},t}^{Valve}} \cdot \textcolor{green}{\rho.g}
+         - \textcolor{red}{H_{\tilde{l},l,t}^{Friction, HW}} \cdot \textcolor{green}{\rho.g}
+         - \textcolor{red}{H_{l,\tilde{l},t}^{Pump}} \cdot \textcolor{green}{\rho.g}
+         + \textcolor{red}{H_{l,\tilde{l},t}^{Valve}} \cdot \textcolor{green}{\rho.g}
 
+    .. math::
+         \textcolor{blue}{\tilde{l},l \notin LLA}
+        \textcolor{red}{P_{l,t}} + \textcolor{green}{\zeta_{l}} \cdot \textcolor{green}{\rho.g}
+         = \textcolor{red}{P_{\tilde{l},t}} + \textcolor{green}{\zeta_{\tilde{l}}} \cdot \textcolor{green}{\rho.g}
+         + \textcolor{red}{H_{l,\tilde{l},t}^{Friction, HW}} \cdot \textcolor{green}{\rho.g}
+         - \textcolor{red}{H_{l,\tilde{l},t}^{Pump}} \cdot \textcolor{green}{\rho.g}
+         + \textcolor{red}{H_{l,\tilde{l},t}^{Valve}} \cdot \textcolor{green}{\rho.g}
 
     **Pump cost rule:** :math:`\forall \textcolor{blue}{l,\tilde{l} \in LLA}`
 

--- a/pareto/strategic_water_management/run_strategic_model.py
+++ b/pareto/strategic_water_management/run_strategic_model.py
@@ -164,7 +164,7 @@ strategic_model = create_model(
         "objective": Objectives.cost,
         "pipeline_cost": PipelineCost.distance_based,
         "pipeline_capacity": PipelineCapacity.input,
-        "hydraulics": Hydraulics.false,
+        "hydraulics": Hydraulics.co_optimize,
         "node_capacity": True,
         "water_quality": WaterQuality.false,
         "removal_efficiency_method": RemovalEfficiencyMethod.concentration_based,

--- a/pareto/strategic_water_management/strategic_produced_water_optimization.py
+++ b/pareto/strategic_water_management/strategic_produced_water_optimization.py
@@ -216,7 +216,7 @@ CONFIG.declare(
 
 
 # This is the basic length of refinement of the grid. Adjust to 1000 for 10 times more refinement
-discretization_unit = 10000
+Del_I = 10000
 
 def create_model(df_sets, df_parameters, default={}):
     model = ConcreteModel()
@@ -490,9 +490,9 @@ def create_model(df_sets, df_parameters, default={}):
     )
 
     # Define sets for the piecewise linear approximation
-    model.s_lamset = Set(initialize= list(range(1+int(70000/discretization_unit))))
-    model.s_lamset2 = Set(initialize= list(range(int(70000/discretization_unit) )))
-    model.s_zset = Set(initialize= list(range(math.ceil(math.log(8, 2)))) )
+    model.s_lamset = Set(initialize= list(range(1+int(70000/Del_I))))
+    model.s_lamset2 = Set(initialize= list(range(int(70000/Del_I) )))
+    model.s_zset = Set(initialize= list(range(math.ceil(math.log(1+int(70000/Del_I), 2)))) )
 
     # Define continuous variables #
 
@@ -4200,7 +4200,7 @@ def pipeline_hydraulics(model):
 
         def FlowEquationConvRule(b, l1, l2, t1):
             constraint = model.v_F_Piped[l1, l2, t1]* cons_scaling_factor\
-            == sum(mh.v_lambdas[l1, l2, t1, k]*discretization_unit*k for k in model.s_lamset)* cons_scaling_factor
+            == sum(mh.v_lambdas[l1, l2, t1, k]*Del_I*k for k in model.s_lamset)* cons_scaling_factor
             return process_constraint(constraint)
 
         mh.FlowEquationConv = Constraint(
@@ -4214,7 +4214,7 @@ def pipeline_hydraulics(model):
         def termEquationConvRule(b, l1, l2, t1):
             constraint =\
                 mh.v_term[l1, l2, t1]\
-            == sum(mh.v_lambdas[l1, l2, t1, k]*(k*discretization_unit*1.84*10**(-6))**1.85 for k in model.s_lamset)
+            == sum(mh.v_lambdas[l1, l2, t1, k]*(k*Del_I*1.84*10**(-6))**1.85 for k in model.s_lamset)
             return process_constraint(constraint)
 
         mh.termEquationConv = Constraint(


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Co-optimize method had two non-linearities: Hazen-William Rule and Pump Cost rule. These non-linearities result in a very slow computation by non-linear solvers. We make piecewise linearization of the term flow raised to the power 1.85 in the RHS of Hazen-Williams equation. In the LHS of the same equation, we model the product of pressure change and diameter selection binaries with a set of linear constraints. Finally, for the variable (electricity) component of the pump cost we use 1609 in place of pressure change variable because this is average pressure change of all the pumps observed for the toy case study problem. Thus, the formulation is completely linearized.

## Changes proposed in this PR:

- the term in RHS of Hazen-William equation is modeled using a piecewise linear function. 
**Brief idea:** Consider a non-linear function of one variable with any point on the curve represented by (x, f(x)). We can fit a piecewise linear function as an approximation to f(x). Say the new point (x, y) is an approximation of the original point as shown in the figure below. Then, it is possible to model this (x, y) as a system of linear constraints. This can be done by introducing logarithmic number of binary variables as the number of sections of piecewise linear graph. Refer section 2 of https://link.springer.com/chapter/10.1007/978-1-4614-1927-3_10
![Piecewise_linear_fit](https://github.com/project-pareto/project-pareto/assets/66786226/4ddaad28-45b0-40cc-b8c1-aa4a2f94696c)


- For LHS of the Hazen-William equation, we have a multiplication of non-negative continuous variable(pressure drop) and binary variable(diameter choice). When we have such a product, it can be modeled using linear constraints. For example, consider a term P = Hz where H is a non-negative continuous variable with upper bound M and z is a binary variable. Then we can model P using 
a) P>=0  b) P<=H  c) P<=Mz  d) P>= H - M(1-z)

- In Pump cost rule, 1609 is used in place of PumpHead variable as this is the average pressure gain due to all pumps for the toy case study problem.

-  The documentation of hydraulics is updated to reflect the proposed changes in the formulation. 
-  Node pressure rule for co_optimize method is corrected in the documentation. Earlier it had flipped sign of pump head and valve release. 


### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
