### PR TITLE
Fix and reformat earthquake distance tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -80,7 +80,7 @@ jobs:
           python -m pareto.tests.toy_case_study
       - name: Upload coverage report as job artifact
         if: matrix.cov-report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml
@@ -92,14 +92,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # the checkout step is needed to have access to codecov.yml
-      - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: coverage-report
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
+          verbose: true
+          # NOTE: secrets are not available for pull_request workflows
+          # However, as of 2024-02-10, Codecov is still allowing tokenless upload from PRs
+          # but does require token for other workflows e.g. merge to `main`
+          # see https://github.com/codecov/codecov-action/issues/1274#issuecomment-1934437359
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   black:
     name: Run Black to verify that committed code is formatted


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Reformat `pareto/tests/test_earthquake_distance.py` into multiple small tests instead of one large test, and mark with `@pytest.mark.xfail` the test which is failing in the GitHub environment.

Update codecov-action to v4 to hopefully resolve the persistent failures we're seeing using v2

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
