### PR TITLE
Update conda to use miniforge

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,7 +7,6 @@ version: 2
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-  configuration: docs/conf.py
   fail_on_warning: true
   configuration: docs/conf.py
 

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -37,16 +37,15 @@ repo (even occasionally) - needs approval from PhD. Markus Drouven
 | Hybrid           | :ref:`min_install_hybrid`   |
 +------------------+-----------------------------+
 
-**Install Miniconda (optional)**
+**Install Conda via Miniforge (optional)**
 
-1. Download: https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe
-2. Install anaconda from the downloaded file in (1).
-3. Open the Anaconda Prompt (Start -> "Anaconda Prompt").
+.. note:: If you are using Python for other complex projects, you may want to
+          consider using environments of some sort to avoid conflicting
+          dependencies.  Conda via Miniforge is one such tool.
 
-.. warning:: If you are using Python for other complex projects, you may want to
-            consider using environments of some sort to avoid conflicting
-            dependencies.  There are several good options including conda
-            environments if you use Anaconda.
+1. Download the Miniforge installer for your OS: https://github.com/conda-forge/miniforge/releases
+2. Install Miniforge from the downloaded file in (1).
+3. Open a terminal to run the below commands.
 
 .. _min_install_users:
 


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

Fixes #350 

## Changes proposed in this PR:
- Change instructions for installing conda to install from miniforge
- Also fixed a duplicate entry in `.readthedocs.yaml` on where to find `conf.py`

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
