### PR TITLE
updating RTD ubuntu runner and python

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,9 +11,9 @@ sphinx:
   configuration: docs/conf.py
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-24.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 python:
   install:


### PR DESCRIPTION
## Fixes/Addresses/Summary/Motivation:

RTD is deprecating ubuntu 20.04, this updates it to us 24.04 and python 3.10 (from 3.9)

## Changes proposed in this PR:
-
-

### Legal Acknowledgement

By contributing to this software project, I agree to the following terms and conditions for my
contribution:

1. I agree my contributions are submitted under the license terms described in the LICENSE.md file
   at the top level of this directory.
2. I represent I am authorized to make the contributions and grant the license. If my employer has
   rights to intellectual property that includes these contributions, I represent that I have
   received permission to make contributions and grant the required license on behalf of that
   employer.
